### PR TITLE
[html-highlight] Highlight html in vs code

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ After installing dependencies using `npm install` the following scripts are avai
 `lint:fix` | Checks code for code style violations and fixes them when possible.
 `test` | Runs linting.
 
+## HTML syntax highlighting in `*-preview.js` files
+
+Since the markup of the preview is generated with template literals in plain 
+`.js` files, you don't get syntax highlighting for the markup.
+For VS Code there is a solution in the form of the LitHtml extension. Although 
+this project does not use LitHtml, we can trick the plugin in thinking it does,
+and thus provide syntax highlighting.
+
+The `html` lib function is a mock function which tricks the LitHtml extension
+into providing the syntax highlight.
+
+### Setup
+
+1. Install the [extension](https://marketplace.visualstudio.com/items?itemName=bierner.lit-html)
+2. Import the lib function `html` from `/src/heads-up/lib/html.js` in your file
+3. Tag the template literal with the `html` function `const htmlString = html``<p>Some markup here</p>`
+
 
 ## License
 

--- a/src/facebook-desktop-preview/facebook-desktop-preview.js
+++ b/src/facebook-desktop-preview/facebook-desktop-preview.js
@@ -1,3 +1,5 @@
+import html from '../heads-up/lib/html'
+
 createPreview()
 
 function createPreview() {
@@ -34,17 +36,17 @@ function getHostName(url) {
 function getfacebookMarkup({ title, description, img, url, desktopImgIsBig, imageSpecified
 }) {
 
-  return `
+  return html`
   <div class="facebook-preview">
     <a rel="noopener" target="_blank" class="facebook-preview__link-container facebook-preview__link-container--vertical ${desktopImgIsBig ? "" : "facebook-preview__small"}">
-      
-    ${imageSpecified ? `
+
+    ${imageSpecified ? html`
     <div class="${ img === "undefined"
         ? `facebook-preview__media facebook-preview__media--image-fallback`
         : `facebook-preview__fixed-ratio facebook-preview__ratio`}">
         ${ img === "undefined"
         ? ``
-        : `<img src="${img}" class="facebook-preview__fixed-ratio-content" />`}
+        : html`<img src="${img}" class="facebook-preview__fixed-ratio-content" />`}
       </div>
       `: ``
     }
@@ -53,7 +55,7 @@ function getfacebookMarkup({ title, description, img, url, desktopImgIsBig, imag
       <div class="facebook-preview__hostname">${ getHostName(url)}</div>
         <div class="facebook-preview__content">
           <div class="facebook-preview__title">${ title ? title : getHostName(url)}</div>
-          ${description === "null" ? "" : `<div class="facebook-preview__description">${description}</div>`}
+          ${description === "null" ? "" : html`<div class="facebook-preview__description">${description}</div>`}
         </div>
       </div>
     </a>

--- a/src/facebook-mobile-preview/facebook-mobile-preview.js
+++ b/src/facebook-mobile-preview/facebook-mobile-preview.js
@@ -1,3 +1,5 @@
+import html from '../heads-up/lib/html'
+
 createPreview()
 
 function createPreview() {
@@ -34,17 +36,17 @@ function getHostName(url) {
 function getfacebookMarkup({ title, description, img, url, mobileImgIsBig, imageSpecified
 }) {
 
-  return `
+  return html`
   <div class="facebook-preview">
     <a rel="noopener" target="_blank" class="facebook-preview__link-container facebook-preview__link-container--vertical ${mobileImgIsBig ? "" : "facebook-preview__small"}">
-      
-    ${imageSpecified ? `
+
+    ${imageSpecified ? html`
     <div class="${ img === "undefined"
         ? `facebook-preview__media facebook-preview__media--image-fallback`
         : `facebook-preview__fixed-ratio facebook-preview__ratio`}">
         ${ img === "undefined"
         ? ``
-        : `<img src="${img}" class="facebook-preview__fixed-ratio-content" />`}
+        : html`<img src="${img}" class="facebook-preview__fixed-ratio-content" />`}
       </div>
       `: ``
     }
@@ -53,7 +55,7 @@ function getfacebookMarkup({ title, description, img, url, mobileImgIsBig, image
       <div class="facebook-preview__hostname">${ getHostName(url)}</div>
         <div class="facebook-preview__content">
           <div class="facebook-preview__title">${ title}</div>
-          ${description === "null" ? "" : `<div class="facebook-preview__description">${description}</div>`}
+          ${description === "null" ? "" : html`<div class="facebook-preview__description">${description}</div>`}
         </div>
       </div>
     </a>

--- a/src/heads-up/lib/html.js
+++ b/src/heads-up/lib/html.js
@@ -1,0 +1,21 @@
+/**
+ * Tagged template function allowing VS Code (in combination with the `lit-html`
+ * extension) to give syntax highlighting to HTML strings
+ *
+ * Find the `lit-html` extension here:
+ * https://marketplace.visualstudio.com/items?itemName=bierner.lit-html
+ *
+ * @param {*} strings
+ * @param  {...any} values
+ *
+ * @example
+ * import html from './lib/html'
+ * const htmlString = html`<p>Some markup here</p>`
+ */
+export default function html (strings, ...values) {
+  let str = "";
+  strings.forEach((string, i) => {
+    str += string + values[i];
+  });
+  return str;
+}

--- a/src/linkedin-preview/linkedin-preview.js
+++ b/src/linkedin-preview/linkedin-preview.js
@@ -1,3 +1,4 @@
+import html from '../heads-up/lib/html'
 
 createPreview()
 
@@ -32,7 +33,7 @@ function getHostName(url) {
 
 function getlinkedinMarkup({ title, image, url, imageIsBig }) {
 
-  const like = `<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+  const like = html`<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
   viewBox="0 0 43.6 43.6" style="enable-background:new 0 0 43.6 43.6;" xml:space="preserve">
 <style type="text/css">
  .st0{fill:none;}
@@ -86,13 +87,13 @@ function getlinkedinMarkup({ title, image, url, imageIsBig }) {
 </g>
 </svg>`
 
-  return `
+  return html`
       <div class="linkedin-preview">
         <a rel="noopener" target="_blank" class="linkedin-preview__link-container ${imageIsBig ? "" : "linkedin-preview__small"}">
           <div class="${ image ? `linkedin-preview__fixed-ratio linkedin-preview__ratio` : `linkedin-preview__media linkedin-preview__media--image-fallback`}">
             ${ image
-      ? `   <img src="${image}" class="linkedin-preview__fixed-ratio-content"/>`
-      : `   <div class="linkedin-preview__image-fallback"></div>`}
+      ? html`   <img src="${image}" class="linkedin-preview__fixed-ratio-content"/>`
+      : html`   <div class="linkedin-preview__image-fallback"></div>`}
           </div>
 
           <div class="linkedin-preview__content">

--- a/src/twitter-preview/twitter-preview.js
+++ b/src/twitter-preview/twitter-preview.js
@@ -1,3 +1,4 @@
+import html from '../heads-up/lib/html'
 
 createPreview()
 
@@ -44,7 +45,7 @@ function getTwitterMarkup({ title, description, image, url, type }) {
 
     }
 
-    return `
+    return html`
       <div class="${ type === 'summary' ? `twitter-preview is-small` : `twitter-preview` }">
         <a rel="noopener" target="_blank" ${ twitterLink } class="${ type === 'summary' ? `twitter-preview__link-container` : `twitter-preview__link-container twitter-preview__link-container--vertical` } ">
           <div class="${ image
@@ -53,10 +54,10 @@ function getTwitterMarkup({ title, description, image, url, type }) {
               : `twitter-preview__fixed-ratio twitter-preview__ratio` }`
             : `twitter-preview__media twitter-preview__media--image-fallback` }">
             ${ image
-              ? `<img src="${ image }" class="${ type === 'summary'
+              ? html`<img src="${ image }" class="${ type === 'summary'
                 ? `twitter-preview__image`
                 : `twitter-preview__fixed-ratio-content` }" />`
-              : `<div class="twitter-preview__image-fallback"></div>` }
+              : html`<div class="twitter-preview__image-fallback"></div>` }
           </div>
 
           <div class="twitter-preview__content">

--- a/src/whatsapp-preview/whatsapp-preview.js
+++ b/src/whatsapp-preview/whatsapp-preview.js
@@ -1,3 +1,4 @@
+import html from '../heads-up/lib/html'
 
 createPreview()
 
@@ -35,14 +36,14 @@ function getHostName(url) {
 
 function getwhatsappMarkup({ title, description, image, url, }) {
 
-  return `
+  return html`
       <div class="whatsapp-preview">
         <a rel="noopener" target="_blank">
-        <div class="whatsapp-top">  
-          ${ image ? `<div class="whatsapp-preview__media"><img src="${image}" class="whatsapp-preview__image" /></div>` : ``}
+        <div class="whatsapp-top">
+          ${ image ? html`<div class="whatsapp-preview__media"><img src="${image}" class="whatsapp-preview__image" /></div>` : ``}
           <div>
           <div class="whatsapp-preview__content">
-          ${title !== 'undefined' ? `<div class="whatsapp-preview__title">${title}</div>` : ''}
+          ${title !== 'undefined' ? html`<div class="whatsapp-preview__title">${title}</div>` : ''}
           <div class="whatsapp-preview__description">${description}</div>
           </div>
           <div class="whatsapp-preview__url">${ getHostName(url)}</div>
@@ -51,12 +52,12 @@ function getwhatsappMarkup({ title, description, image, url, }) {
           <div class="whatsapp-preview__domain">
               <div class="whatsapp-preview__hostname">${ url}
               <span class="whatsapp-preview__timewrapper">
-                <time class="whatsapp-preview__time">${currentTime()}</time>   
+                <time class="whatsapp-preview__time">${currentTime()}</time>
                 <span class="whatsapp-preview__checkmark"><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 15" width="16" height="15"><path fill="#4FC3F7" d="M15.01 3.316l-.478-.372a.365.365 0 0 0-.51.063L8.666 9.879a.32.32 0 0 1-.484.033l-.358-.325a.319.319 0 0 0-.484.032l-.378.483a.418.418 0 0 0 .036.541l1.32 1.266c.143.14.361.125.484-.033l6.272-8.048a.366.366 0 0 0-.064-.512zm-4.1 0l-.478-.372a.365.365 0 0 0-.51.063L4.566 9.879a.32.32 0 0 1-.484.033L1.891 7.769a.366.366 0 0 0-.515.006l-.423.433a.364.364 0 0 0 .006.514l3.258 3.185c.143.14.361.125.484-.033l6.272-8.048a.365.365 0 0 0-.063-.51z"></path></svg>
-                </span> 
+                </span>
           </span>
               </div>
-              
+
         </a>
         <span class="whatsapp-preview__tail">
         <svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"


### PR DESCRIPTION
Since we have quite some markup generated in plain `.js` files, we run in
the problem that we don't have syntaxt highlighting. This lib function in
combination with the LitHtml extension for VS Code solves this problem

This is implemented by creating a mock tagged template literal function.
The LitHtml extension for VSCode generates syntaxt highlighting for html
when it finds a tagged template literal with the tag of html. The lib
function is a mock function