### PR TITLE
fix(properties-item) remove extra space in link

### DIFF
--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -66,12 +66,7 @@
         </template>
 
         <template #link>
-          <external-link
-            class="properties-item__link"
-            :href="link"
-          >
-            Learn more
-          </external-link>
+          <external-link class="properties-item__link" :href="link">Learn more</external-link>
         </template>
       </app-tooltip>
     </span>


### PR DESCRIPTION
Removes extra space at the start of the link text.