### PR TITLE
Feat/Add sitemap from txt

### DIFF
--- a/projects/browser-extension/vue-app/src/store/index.js
+++ b/projects/browser-extension/vue-app/src/store/index.js
@@ -58,18 +58,36 @@ export default createStore({
       const { sitemapUrls } = state;
       let sitemaps = [];
 
-      function createSitemapResponse(url) {
-        return fetch(url)
-          .then(res => res.text())
-          .then(text => parseStringPromise(text, {
+      async function createSitemapResponse(url) {
+        const isXml = url => /.xml$/.test(url);
+        const isTxt = url => /.txt$/.test(url);
+
+        const parseTextContent = content => ({
+          sitemap: content
+            .split('\n')
+            .map(line => ({ loc: line })),
+        });
+
+        let content = await fetch(url)
+          .then(res => res.text());
+
+        if (isXml(url)) {
+          content = parseStringPromise(content, {
             emptyTag: null,
             explicitArray: false,
             explicitRoot: false,
             ignoreAttrs: true,
             normalizeTags: true,
             trim: true,
-          }))
-          .catch(() => null);
+          })
+            .catch(() => null);
+        }
+
+        if (isTxt(url)) {
+          content = parseTextContent(content);
+        }
+
+        return content;
       }
 
       function formatSitemapData(data) {

--- a/projects/web-app/functions/api/sitemap.js
+++ b/projects/web-app/functions/api/sitemap.js
@@ -3,11 +3,18 @@ const xml2js = require('xml2js');
 const robotsParser = require('robots-txt-parser')({ allowOnNeutral: false });
 
 const isXml = url => /.xml$/.test(url);
+const isTxt = url => /.txt$/.test(url);
 const objectMap = (obj, fn) => Object.fromEntries(
   Object.entries(obj).map(
     ([ k, v ], i) => [ k, fn(v, k, i) ]
   )
 );
+
+const parseTextContent = content => ({
+  sitemap: content
+    .split('\n')
+    .map(line => ({ loc: line })),
+});
 
 function formatSitemapData(data) {
   return data.map(item => {
@@ -35,6 +42,10 @@ async function createSitemapResponse(url) {
       normalizeTags: true,
       trim: true,
     });
+  }
+
+  if (isTxt(url)) {
+    content = parseTextContent(content);
   }
 
   return content;

--- a/projects/web-app/functions/api/sitemap.js
+++ b/projects/web-app/functions/api/sitemap.js
@@ -30,8 +30,7 @@ function formatSitemapData(data) {
 
 async function createSitemapResponse(url) {
   let content = await fetch(url)
-    .then(res => res.text())
-    .catch(() => null);
+    .then(res => res.text());
 
   if (isXml(url)) {
     content = await xml2js.parseStringPromise(content, {
@@ -41,7 +40,8 @@ async function createSitemapResponse(url) {
       ignoreAttrs: true,
       normalizeTags: true,
       trim: true,
-    });
+    })
+      .catch(() => null);
   }
 
   if (isTxt(url)) {

--- a/projects/web-app/functions/api/sitemap.js
+++ b/projects/web-app/functions/api/sitemap.js
@@ -1,0 +1,81 @@
+const fetch = require('node-fetch');
+const xml2js = require('xml2js');
+const robotsParser = require('robots-txt-parser')({ allowOnNeutral: false });
+
+const isXml = url => /.xml$/.test(url);
+const objectMap = (obj, fn) => Object.fromEntries(
+  Object.entries(obj).map(
+    ([ k, v ], i) => [ k, fn(v, k, i) ]
+  )
+);
+
+function formatSitemapData(data) {
+  return data.map(item => {
+    const { loc, ...data } = item;
+
+    if (Object.keys(item).length === 1 && Object.keys(item)[0] === 'loc') {
+      return loc;
+    }
+
+    return { loc, data };
+  });
+}
+
+async function createSitemapResponse(url) {
+  let content = await fetch(url)
+    .then(res => res.text())
+    .catch(() => null);
+
+  if (isXml(url)) {
+    content = await xml2js.parseStringPromise(content, {
+      emptyTag: null,
+      explicitArray: false,
+      explicitRoot: false,
+      ignoreAttrs: true,
+      normalizeTags: true,
+      trim: true,
+    });
+  }
+
+  return content;
+}
+
+function createSitemapUrlsResponse(domain) {
+  return robotsParser.fetch(domain).then(result => {
+    if (result.sitemaps) {
+      return result.sitemaps;
+    }
+  });
+}
+
+module.exports = async function sitemap(domain) {
+  let sitemaps = [];
+  const sitemapUrls = await createSitemapUrlsResponse(domain);
+
+  if (sitemapUrls && sitemapUrls.length) {
+    const sitemapResponses = await Promise.all(
+      sitemapUrls.map(url => createSitemapResponse(url))
+    );
+
+    sitemaps = sitemapUrls.map((url, index) => {
+      const sitemapResponse = sitemapResponses[index];
+
+      if (!sitemapResponse) {
+        return {
+          sitemapData: null,
+          sitemapUrl: url,
+        };
+      }
+
+      return {
+        sitemapData: objectMap(sitemapResponse, v => formatSitemapData(v)),
+        sitemapUrl: url,
+      };
+    });
+  }
+
+  return {
+    sitemaps,
+    sitemapUrls,
+  };
+};

--- a/projects/web-app/src/views/sitemap.view.vue
+++ b/projects/web-app/src/views/sitemap.view.vue
@@ -4,8 +4,8 @@
       <div v-if="!sitemaps.length" class="warning-message">
         <WarningIcon class="icon" />
         <p>
-          No sitemap found at
-          <external-link :href="sitemapUrl">{{ sitemapUrl }}</external-link>.
+          No Sitemap reference found in
+          <external-link :href="`${url}/robots.txt`">/robots.txt</external-link>.
         </p>
       </div>
       <details
@@ -62,13 +62,10 @@ export default {
   setup: () => {
     const headData = useHead().data;
     const sitemaps = computed(() => headData.value.sitemaps);
-    const sitemapUrl = computed(() => {
-      return headData.value.head.domain + '/sitemap.xml';
-    });
 
     return {
       sitemaps,
-      sitemapUrl,
+      url: headData.value.head.url,
     };
   },
   components: {


### PR DESCRIPTION
Add sitemaps from .txt files

## What change(s) were made
* Move sitemap logic into seperate file in api.js
* Allow for sitemaps from .txt files
* Update error message in web app
  The previous error message explained that the /sitemap.xml could not be
  found. But we never look at /sitemap.xml when looking for sitemaps. The api
  is using /robots.txt to search for sitemap references.
  This error message explains that. Otherwise, a sitemap.xml can be present
  on the server, but could not be found by us because we are not looking for
  it directly

## How to test
- http://localhost:8888/sitemap
- Use page with .txt sitemaps (https://www.petergoes.nl)

## Related Trello ticket(s)
https://trello.com/c/M0Kkj6HQ/10-add-sitemap-plain-text