### PR TITLE
Fix/theme support Structured Data preview

### DIFF
--- a/projects/browser-extension/vue-app/src/views/structured-data.view.vue
+++ b/projects/browser-extension/vue-app/src/views/structured-data.view.vue
@@ -80,10 +80,10 @@ export default {
 
 <style>
   .structured-data__code-block {
-    background-color: #f9f9f9;
-    border: 1px solid #eee;
     max-height: 50vh;
-    overflow: auto;
     padding: 0.5rem;
+    overflow: auto;
+    border: var(--divider-border);
+    background-color: var(--toolbar-bg-color);
   }
 </style>

--- a/projects/web-app/src/style/variables.css
+++ b/projects/web-app/src/style/variables.css
@@ -6,6 +6,7 @@
   --color-blue: #0000ff;
   --color-black: #141414;
   --color-gray: #c0c0c0;
+  --color-light-gray: #eaeaea;
   --color-white: #ffffff;
 
   --divider-color: #d0d0d0;
@@ -17,4 +18,5 @@
   --sidebar-width: 17rem;
 
   --label-color: #5f5f5f;
+  --bg-color: var(--color-light-gray);
 }

--- a/projects/web-app/src/views/structured-data.view.vue
+++ b/projects/web-app/src/views/structured-data.view.vue
@@ -73,10 +73,11 @@ export default {
 
 <style>
   .structured-data__code-block {
-    background-color: #f9f9f9;
-    border: 1px solid #eee;
     max-height: 50vh;
-    overflow: auto;
     padding: 0.5rem;
+    overflow: auto;
+    border: 1px solid var(--divider-color);
+    background-color: var(--bg-color);
+    font-size: 14px;
   }
 </style>


### PR DESCRIPTION
## What change(s) were made
- Added support for light/dark theming to the Structured Data preview.

## How to test
- Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
- Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
[https://trello.com/c/xnv4Xz7Z](https://trello.com/c/xnv4Xz7Z)
