### PR TITLE
Feat/facebook validation

### DIFF
--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -1,30 +1,65 @@
+import getImageDimensions from './get-image-dimensions';
+
 // Docs: https://joi.dev/api/?v=17.4.0#anyvalidatevalue-options
 const JOI_VALIDATION_OPTIONS = {
   abortEarly: false,
   convert: false,
 };
 
-const validateData = (data, schema) => {
-  if (!data.length) {
-    return { errors: 'No data to validate' };
-  }
+/**
+ * Transforms the data array into an object that Joi can validate.
+ *
+ * @param {Array} data
+ */
+const transformData = data => {
+  const array = data
+    .map(async item => {
+      const { type, image } = item;
+      if (type === 'image') {
+        /* Because Joi Extensions cannot be async (yet): https://github.com/sideway/joi/issues/1194)
+        we get the image dimensions here and add them to the data that wil be validated.
+        ¯\_(ツ)_/¯ */
+        const { width, height } = await getImageDimensions(image.url);
 
-  // Convert incoming data into schema data object.
-  const schemaData = Object.assign({},
-    ...data.map(data => ({
-      [data.term]: data.value,
-    }))
-  );
+        return {
+          ...item,
+          value: { url: image.url, width, height },
+        };
+      }
 
+      return item;
+    });
+
+  return Promise.all(array)
+    .then(array => array.map(item => ({ [item.term]: item.value })))
+    .then(array => (Object.assign({}, ...array)));
+};
+
+/**
+ * Validate data with given schema and return the results.
+ *
+ * @param {Object} data
+ * @param {Object} schema
+ */
+const validateDataWithSchema = (data, schema) => {
   try {
     // Docs: https://joi.dev/api/?v=17.4.0#anyvalidate
-    const { error, warning } = schema.validate(schemaData, JOI_VALIDATION_OPTIONS);
+    const { error, warning } = schema.validate(data, JOI_VALIDATION_OPTIONS);
     // Return any errors and warnings.
     return { errors: error?.details, warnings: warning?.details };
   } catch (err) {
-    console.log(err);
     return { errors: err };
   }
 };
 
-export default validateData;
+const validate = (data, schema) => {
+  if (!data.length) {
+    return { errors: 'No data to validate' };
+  }
+
+  return transformData(data)
+    .then(data => validateDataWithSchema(data, schema))
+    .catch(err => console.log(err));
+};
+
+export default validate;

--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -36,10 +36,10 @@ const transformData = data => {
 };
 
 /**
- * Validate data with given schema and return the results.
+ * Validate with Joi and return any errors and/or warnings.
  *
- * @param {Object} data
- * @param {Object} schema
+ * @param {Object} data - data to validate
+ * @param {Object} schema - schema to validate data with
  * @returns {Object}
  */
 const validateDataWithSchema = (data, schema) => {
@@ -53,6 +53,13 @@ const validateDataWithSchema = (data, schema) => {
   }
 };
 
+/**
+ * Transform data, validate it with the given schema and return the results.
+ *
+ * @param {Array} data - data to validate
+ * @param {Object} schema - schema to validate data with
+ * @returns {Promise}
+ */
 const validate = (data, schema) => {
   if (!data.length) {
     return { errors: 'No data to validate' };

--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -62,7 +62,7 @@ const validateDataWithSchema = (data, schema) => {
  */
 const validate = (data, schema) => {
   if (!data.length) {
-    return { errors: 'No data to validate' };
+    return Promise.resolve({ errors: 'No data to validate' });
   }
 
   return transformData(data)

--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -10,6 +10,7 @@ const JOI_VALIDATION_OPTIONS = {
  * Transforms the data array into an object that Joi can validate.
  *
  * @param {Array} data
+ * @returns {Promise}
  */
 const transformData = data => {
   const array = data
@@ -39,6 +40,7 @@ const transformData = data => {
  *
  * @param {Object} data
  * @param {Object} schema
+ * @returns {Object}
  */
 const validateDataWithSchema = (data, schema) => {
   try {

--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -67,7 +67,10 @@ const validate = (data, schema) => {
 
   return transformData(data)
     .then(data => validateDataWithSchema(data, schema))
-    .catch(err => console.log(err));
+    .catch(err => {
+      console.log(err);
+      return Promise.resolve(err);
+    });
 };
 
 export default validate;

--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -15,16 +15,15 @@ const transformData = data => {
   const array = data
     .map(async item => {
       const { type, image } = item;
-      if (type === 'image') {
-        /* Because Joi Extensions cannot be async (yet): https://github.com/sideway/joi/issues/1194)
+      /*
+        Because Joi Extensions cannot be async (yet): https://github.com/sideway/joi/issues/1194)
         we get the image dimensions here and add them to the data that wil be validated.
-        ¯\_(ツ)_/¯ */
+        ¯\_(ツ)_/¯
+      */
+      if (type === 'image') {
         const { width, height } = await getImageDimensions(image.url);
-
-        return {
-          ...item,
-          value: { url: image.url, width, height },
-        };
+        const value = image.url ? { url: image.url, width, height } : image.url;
+        return { ...item, value };
       }
 
       return item;

--- a/projects/@shared/lib/validator/extensions/image.js
+++ b/projects/@shared/lib/validator/extensions/image.js
@@ -1,0 +1,150 @@
+import { isArray } from 'lodash';
+
+const image = joi => ({
+  type: 'image',
+  base: joi.object(),
+  messages: {
+    'image.minWidth': '{{#label}} must be at least {{#width}}px wide.',
+    'image.maxWidth': '{{#label}} must be no more than {{#width}}px wide.',
+    'image.minHeight': '{{#label}} must be at least {{#height}}px high.',
+    'image.maxHeight': '{{#label}} must be no more than {{#height}}px high.',
+    'image.minDimensions': '{{#label}} should avoid images smaller than {{#width}}x{{#height}} or less.',
+    'image.maxDimensions': '{{#label}} should avoid images larger than {{#width}}x{{#height}} or more.',
+  },
+  rules: {
+    minWidth: {
+      method(width) {
+        return this.$_addRule({ name: 'minWidth', args: { width } });
+      },
+      args: [
+        {
+          name: 'width',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        if (value.width < args.width) {
+          return { value, warn: helpers.warn('image.minWidth', { width: args.width }) };
+        }
+
+        return { value };
+      },
+    },
+    maxWidth: {
+      method(width) {
+        return this.$_addRule({ name: 'maxWidth', args: { width } });
+      },
+      args: [
+        {
+          name: 'width',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        if (value.width > args.width) {
+          return { value, warn: helpers.warn('image.maxWidth', { width: args.width }) };
+        }
+
+        return { value };
+      },
+    },
+    minHeight: {
+      method(height) {
+        return this.$_addRule({ name: 'minHeight', args: { height } });
+      },
+      args: [
+        {
+          name: 'height',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        if (value.height < args.height) {
+          return { value, warn: helpers.warn('image.minHeight', { height: args.height }) };
+        }
+
+        return { value };
+      },
+    },
+    maxHeight: {
+      method(height) {
+        return this.$_addRule({ name: 'maxHeight', args: { height } });
+      },
+      args: [
+        {
+          name: 'height',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        if (value.height > args.height) {
+          return { value, warn: helpers.warn('image.maxHeight', { height: args.height }) };
+        }
+
+        return { value };
+      },
+    },
+    minDimensions: {
+      method(width, height) {
+        return this.$_addRule({ name: 'minDimensions', args: { width, height } });
+      },
+      args: [
+        {
+          name: 'width',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+        {
+          name: 'height',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        if (value.height < args.height || value.width < args.width) {
+          return { value, warn: helpers.warn('image.minDimensions', { width: args.width, height: args.height }) };
+        }
+
+        return { value };
+      },
+    },
+    maxDimensions: {
+      method(width, height) {
+        return this.$_addRule({ name: 'maxDimensions', args: { width, height } });
+      },
+      args: [
+        {
+          name: 'width',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+        {
+          name: 'height',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        if (value.height > args.height || value.width > args.width) {
+          return { value, warn: helpers.warn('image.maxDimensions', { width: args.width, height: args.height }) };
+        }
+
+        return { value };
+      },
+    },
+  },
+});
+
+export default image;

--- a/projects/@shared/lib/validator/extensions/language.js
+++ b/projects/@shared/lib/validator/extensions/language.js
@@ -11,11 +11,6 @@ const language = joi => ({
   messages: {
     'language.base': 'The {{#label}} value should meet the bcp47 standards.',
   },
-  coerce(value) {
-    if (value) {
-      return { value: value.trim() };
-    }
-  },
   validate(value, helpers) {
     if (!validateCountryCodes().includes(value)) {
       return { value, errors: helpers.error('language.base') };

--- a/projects/@shared/lib/validator/extensions/viewport.js
+++ b/projects/@shared/lib/validator/extensions/viewport.js
@@ -55,11 +55,6 @@ const viewport = joi => ({
     'viewport.keys': 'The keys of the viewport meta tag are invalid.',
     'viewport.zoomBlocking': 'The <code>user-scalable</code>, <code>maximum-scale</code>, and <code>minimum-scale</code> can block the user from zooming an a page.',
   },
-  coerce(value) {
-    if (value) {
-      return { value: value.trim() };
-    }
-  },
   validate(value, helpers) {
     if (!hasValidViewportKeys(value)) {
       return { value, errors: helpers.error('viewport.keys') };

--- a/projects/@shared/lib/validator/extensions/words.js
+++ b/projects/@shared/lib/validator/extensions/words.js
@@ -10,11 +10,6 @@ const words = joi => ({
     'words.base': '{{#label}} must have at least 1 word',
     'words.minWords': '{{#label}} must be at least {{#words}} words or more.',
   },
-  coerce(value, helpers) {
-    if (helpers.schema.$_getRule('minWords')) {
-      return { value: value.trim() };
-    }
-  },
   validate(value, helpers) {
     // Base validation regardless of the rules applied.
     if (value && value.length <= 1) {

--- a/projects/@shared/lib/validator/index.js
+++ b/projects/@shared/lib/validator/index.js
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import image from './extensions/image';
 import language from './extensions/language';
 import viewport from './extensions/viewport';
 import words from './extensions/words';
@@ -6,6 +7,7 @@ import words from './extensions/words';
 let validator = Joi;
 
 const extensions = [
+  joi => image(joi),
   joi => language(joi),
   joi => viewport(joi),
   joi => words(joi),

--- a/projects/@shared/views/facebook/facebook.view.vue
+++ b/projects/@shared/views/facebook/facebook.view.vue
@@ -194,21 +194,13 @@ export default {
       },
       {
         term: 'og:video',
-        value: og.value.video,
-        image: {
-          href: og.value.video,
-          url: absoluteUrl(og.value.video),
-        },
-        type: 'image',
+        value: absoluteUrl(og.value.video),
+        type: 'link',
       },
       {
         term: 'og:video:url',
-        value: og.value.videoUrl,
-        image: {
-          href: og.value.videoUrl,
-          url: absoluteUrl(og.value.videoUrl),
-        },
-        type: 'image',
+        value: absoluteUrl(og.value.videoUrl),
+        type: 'link',
       },
       {
         term: 'og:video:secure_url',

--- a/projects/@shared/views/facebook/facebook.view.vue
+++ b/projects/@shared/views/facebook/facebook.view.vue
@@ -244,7 +244,8 @@ export default {
 
     onMounted(() => getImageDimensions());
 
-    validation.value = validate(metaData.value, schema);
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
 
     return {
       TABS,

--- a/projects/@shared/views/facebook/facebook.view.vue
+++ b/projects/@shared/views/facebook/facebook.view.vue
@@ -19,17 +19,18 @@
     </panel-section>
     <panel-section title="Properties">
       <properties-list>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
           :image="item.image"
           :type="item.type"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
           :required="item.required"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -50,12 +51,13 @@ import { TABS } from '@shared/lib/constants.js';
 import createAbsoluteUrl from '@shared/lib/create-absolute-url';
 import { findImageDimensions, findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
 import getTheme from '@shared/lib/theme';
-import schema from './schema';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link';
 import PanelSection from '@shared/components/panel-section';
 import PreviewIframe from '@shared/components/preview-iframe';
-import PropertiesItem from '@shared/components/properties-item';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import PropertiesList from '@shared/components/properties-list';
 import TabSelector from '@shared/components/tab-selector';
 
@@ -68,6 +70,7 @@ export default {
   },
 
   setup: props => {
+    const validation = ref({});
     const openTab = ref(TABS[0].value);
     const imageDimensions = ref({ height: undefined, width: undefined });
     const imageSpecified = ref(true);
@@ -226,6 +229,7 @@ export default {
       },
     ]));
 
+    const getTooltipInfo = term => (info[term] ?? {});
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
     const getImageDimensions = () => findImageDimensions(props.headData.head, 'og:image')
       .then(dimensions => imageDimensions.value = dimensions);
@@ -240,6 +244,8 @@ export default {
 
     onMounted(() => getImageDimensions());
 
+    validation.value = validate(metaData.value, schema);
+
     return {
       TABS,
       openTab,
@@ -247,14 +253,15 @@ export default {
       facebookProperties,
       previewUrl,
       metaData,
-      schema,
+      getTooltipInfo,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
     PreviewIframe,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
     TabSelector,
   },

--- a/projects/@shared/views/facebook/schema.js
+++ b/projects/@shared/views/facebook/schema.js
@@ -1,154 +1,156 @@
-const facebookSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'og:title': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to Facebook\'s developers documentation.',
+    }),
+
+  'og:image': Joi.image()
+    .maxDimensions(600, 600)
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to Facebook\'s developers documentation.',
+    }),
+
+  'og:url': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to Facebook\'s developers documentation.',
+    }),
+
+  'fb:app_id': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to Facebook\'s developers documentation.',
+    }),
+
+  'og:description': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to Facebook\'s developers documentation.',
+    }),
+
+  'fb:pages': Joi.string().allow(''),
+
+  'og:type': Joi.string().allow(''),
+
+  'og:locale': Joi.string().allow(''),
+
+  'og:video': Joi.string().allow(''),
+
+  'og:video:url': Joi.string().allow(''),
+
+  'og:video:secure_url': Joi.string().allow(''),
+
+  'og:video:type': Joi.string().allow(''),
+
+  'og:video:width': Joi.string().allow(''),
+
+  'og:video:height': Joi.string().allow(''),
+
+  'og:image:url': Joi.image()
+    .maxDimensions(600, 600)
+    .allow(''),
+
+  'og:image:secure_url': Joi.string().allow(''),
+
+  'og:image:type': Joi.string().allow(''),
+
+  'og:image:width': Joi.string().allow(''),
+
+  'og:image:height': Joi.string().allow(''),
+});
+
+export const info = {
   'og:title': {
-    required: true,
-    message: {
-      required: 'This property is required according to Facebook\'s developers documentation.',
-    },
-    meta: {
-      info: 'The title of your article without any branding such as your site name.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'The title of your article without any branding such as your site name.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'og:image': {
-    required: true,
-    message: {
-      required: 'This property is required according to Facebook\'s developers documentation.',
-      'image-min-size': 'Avoid images smaller than 600x600 or less.',
-    },
-    'image-min-size': {
-      height: 600,
-      width: 600,
-    },
-    meta: {
-      info: 'The URL of the image that appears when someone shares the content to Facebook. Check out Facebook\'s <a target="_blank" href="https://developers.facebook.com/docs/sharing/best-practices#images">best practices guide</a> to learn how to specify a high quality preview image. To update an image after it\'s been published, use a new URL for the new image. <strong>Images are cached based on the URL and won\'t be updated unless the URL changes.</strong>',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'The URL of the image that appears when someone shares the content to Facebook. Check out Facebook\'s <a target="_blank" href="https://developers.facebook.com/docs/sharing/best-practices#images">best practices guide</a> to learn how to specify a high quality preview image. To update an image after it\'s been published, use a new URL for the new image. <strong>Images are cached based on the URL and won\'t be updated unless the URL changes.</strong>',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'og:url': {
-    required: true,
-    message: {
-      required: 'This property is required according to Facebook\'s developers documentation.',
-    },
-    meta: {
-      info: 'The <a target="_blank" href="https://developers.facebook.com/docs/sharing/webmasters/getting-started/versioned-link">canonical URL</a> for your page. This should be the undecorated URL, without session variables, user identifying parameters, or counters. Likes and Shares for this URL will aggregate at this URL. For example, mobile domain URLs should point to the desktop version of the URL as the canonical URL to aggregate Likes and Shares across different versions of the page.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'The <a target="_blank" href="https://developers.facebook.com/docs/sharing/webmasters/getting-started/versioned-link">canonical URL</a> for your page. This should be the undecorated URL, without session variables, user identifying parameters, or counters. Likes and Shares for this URL will aggregate at this URL. For example, mobile domain URLs should point to the desktop version of the URL as the canonical URL to aggregate Likes and Shares across different versions of the page.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'fb:app_id': {
-    required: true,
-    message: {
-      required: 'This property is required according to Facebook\'s developers documentation.',
-    },
-    meta: {
-      info: 'In order to use <a target="_blank" href="https://developers.facebook.com/docs/sharing/referral-insights">Facebook Insights</a> you must add the app ID to your page. Insights lets you view analytics for traffic to your site from Facebook. Find the app ID in your <a target="_blank" href="https://developers.facebook.com/apps/redirect/dashboard">App Dashboard</a>.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'In order to use <a target="_blank" href="https://developers.facebook.com/docs/sharing/referral-insights">Facebook Insights</a> you must add the app ID to your page. Insights lets you view analytics for traffic to your site from Facebook. Find the app ID in your <a target="_blank" href="https://developers.facebook.com/apps/redirect/dashboard">App Dashboard</a>.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'og:description': {
-    required: true,
-    message: {
-      required: 'This property is required according to Facebook\'s developers documentation.',
-    },
-    meta: {
-      info: 'A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'og:type': {
-    meta: {
-      info: 'The type of media of your content. This tag impacts how your content shows up in News Feed. If you don\'t specify a type,the default is <code>website</code>. Each URL should be a single object, so multiple <code>og:type</code> values are not possible.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'The type of media of your content. This tag impacts how your content shows up in News Feed. If you don\'t specify a type,the default is <code>website</code>. Each URL should be a single object, so multiple <code>og:type</code> values are not possible.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'og:locale': {
-    meta: {
-      info: 'The locale of the resource. Defaults to <code>en_US</code>. You can also use <code>og:locale:alternate</code> if you have other available language translations available.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/',
-    },
+    info: 'The locale of the resource. Defaults to <code>en_US</code>. You can also use <code>og:locale:alternate</code> if you have other available language translations available.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/',
   },
 
   'og:video': {
-    meta: {
-      info: 'The URL for the video. If you want the video to play in-line in News Feed, you should use the https:// URL if possible.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'The URL for the video. If you want the video to play in-line in News Feed, you should use the https:// URL if possible.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:video:url': {
-    meta: {
-      info: 'Equivalent to og:video',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Equivalent to og:video',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:video:secure_url': {
-    meta: {
-      info: 'Secure URL for the video. Include this even if you set the secure URL in og:video.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Secure URL for the video. Include this even if you set the secure URL in og:video.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:video:type': {
-    meta: {
-      info: 'MIME type of the video. Either application/x-shockwave-flash or video/mp4.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'MIME type of the video. Either application/x-shockwave-flash or video/mp4.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:video:width': {
-    meta: {
-      info: 'Width of video in pixels. This property is required for videos.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Width of video in pixels. This property is required for videos.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:video:height': {
-    meta: {
-      info: 'Height of video in pixels. This property is required for videos.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Height of video in pixels. This property is required for videos.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:image:url': {
-    meta: {
-      info: 'Equivalent to <code>og:image</code>',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Equivalent to <code>og:image</code>',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:image:secure_url': {
-    meta: {
-      info: '\'https://\' URL for the image',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: '\'https://\' URL for the image',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:image:type': {
-    meta: {
-      info: 'MIME type of the image. One of <code>image/jpeg</code>, <code>image/gif</code> or <code>image/png</code>',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'MIME type of the image. One of <code>image/jpeg</code>, <code>image/gif</code> or <code>image/png</code>',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:image:width': {
-    meta: {
-      info: 'Width of image in pixels. Specify height and width for your image to ensure that the image loads properly the first time it\'s shared.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Width of image in pixels. Specify height and width for your image to ensure that the image loads properly the first time it\'s shared.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 
   'og:image:height': {
-    meta: {
-      info: 'Height of image in pixels. Specify height and width for your image to ensure that the image loads properly the first time it\'s shared.',
-      link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
-    },
+    info: 'Height of image in pixels. Specify height and width for your image to ensure that the image loads properly the first time it\'s shared.',
+    link: 'https://developers.facebook.com/docs/sharing/webmasters/#media',
   },
 };
-
-export default facebookSchema;

--- a/projects/@shared/views/meta/meta.view.vue
+++ b/projects/@shared/views/meta/meta.view.vue
@@ -30,7 +30,7 @@
 <script>
 import { computed, ref } from 'vue';
 import { findCharset, findMetaContent } from '@shared/lib/find-meta';
-import validateData from '@shared/lib/validate-data';
+import validate from '@shared/lib/validate-data';
 import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link';
@@ -81,7 +81,8 @@ export default {
 
     const getTooltipInfo = term => (info[term] ?? {});
 
-    validation.value = validateData(metaData.value, schema);
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
 
     return {
       getTooltipInfo,

--- a/projects/@shared/views/meta/schema.js
+++ b/projects/@shared/views/meta/schema.js
@@ -2,12 +2,10 @@ import Joi from '../../lib/validator';
 
 export const schema = Joi.object({
   'title': Joi.words()
-    .allow('')
     .min(3)
     .required(),
 
   'lang': Joi.language()
-    .allow('')
     .required(),
 
   'charset': Joi.string()

--- a/projects/web-app/src/components/app-shell/app-shell.vue
+++ b/projects/web-app/src/components/app-shell/app-shell.vue
@@ -46,6 +46,7 @@ export default {
 <style>
 .app {
   display: flex;
+  width: 100vw;
   height: 100vh;
   min-height: 100vh;
 }


### PR DESCRIPTION
Facebook view now uses new Joi validation.

## What change(s) were made
- The `facebook.view.vue` view now uses the new Joi validation.
- New `image` extension to test image sizes and dimensions.
- Validation is now async (see comment in code).
- Removed `coerce` method from all extensions since it's not needed.
- `.app` should be full-width.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/X24SqIwR](https://trello.com/c/X24SqIwR)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
