### PR TITLE
Feat/open graph validation

### DIFF
--- a/projects/@shared/views/open-graph/open-graph.view.vue
+++ b/projects/@shared/views/open-graph/open-graph.view.vue
@@ -11,6 +11,8 @@
           :key="item.term"
           :term="item.term"
           :value="item.value"
+          :image="item.image"
+          :type="item.type"
           :tooltip="getTooltipInfo(item.term)"
           :validation="validation"
           :required="item.required"

--- a/projects/@shared/views/open-graph/open-graph.view.vue
+++ b/projects/@shared/views/open-graph/open-graph.view.vue
@@ -6,14 +6,16 @@
         <p>No Open Graph properties detected.</p>
       </div>
       <properties-list v-else>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
+          :required="item.required"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -29,12 +31,15 @@
 </template>
 
 <script>
-import { computed } from 'vue';
-import schema from './schema';
+import { computed, ref } from 'vue';
+import createAbsoluteUrl from '@shared/lib/create-absolute-url';
+import { findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link';
 import PanelSection from '@shared/components/panel-section';
-import PropertiesItem from '@shared/components/properties-item';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import PropertiesList from '@shared/components/properties-list';
 import WarningIcon from '@shared/assets/icons/warning.svg';
 
@@ -47,27 +52,74 @@ export default {
   },
 
   setup: props => {
-    const metaData = computed(() => {
+    const validation = ref({});
+    const og = computed(() => ({
+      title: propertyValue('og:title'),
+      type: propertyValue('og:type'),
+      image: propertyValue('og:image'),
+      url: propertyValue('og:url'),
+    }));
+    const requiredMetaData = computed(() => [
+      {
+        term: 'og:title',
+        value: og.value.title,
+        required: true,
+      },
+      {
+        term: 'og:type',
+        value: og.value.type,
+        required: true,
+      },
+      {
+        term: 'og:image',
+        value: absoluteUrl(og.value.image),
+        image: {
+          href: og.value.image,
+          url: absoluteUrl(og.value.image),
+        },
+        type: 'image',
+        required: true,
+      },
+      {
+        term: 'og:url',
+        value: og.value.url,
+        required: true,
+      },
+    ]);
+    const headMetaData = computed(() => {
       const { meta } = props.headData.head;
       return meta
         .filter(meta =>
-          meta.property && meta.property.startsWith('og:') || meta.name && meta.name.startsWith('og:')
+          meta.property && meta.property.startsWith('og:') ||
+          meta.name && meta.name.startsWith('og:')
         )
         .map(meta => ({
           term: meta.property || meta.name,
           value: meta.content,
         }));
     });
+    const metaData = computed(() => ([
+      ...requiredMetaData.value,
+      ...headMetaData.value.filter(item => !requiredMetaData.value.find(req => req.term === item.term)),
+    ]));
+
+    const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
+    const getTooltipInfo = term => (info[term] ?? {});
+    const propertyValue = propName =>
+      findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
+
+    validation.value = validate(metaData.value, schema);
 
     return {
+      getTooltipInfo,
       metaData,
-      schema,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
     WarningIcon,
   },

--- a/projects/@shared/views/open-graph/open-graph.view.vue
+++ b/projects/@shared/views/open-graph/open-graph.view.vue
@@ -110,7 +110,8 @@ export default {
     const propertyValue = propName =>
       findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
 
-    validation.value = validate(metaData.value, schema);
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
 
     return {
       getTooltipInfo,

--- a/projects/@shared/views/open-graph/schema.js
+++ b/projects/@shared/views/open-graph/schema.js
@@ -13,8 +13,9 @@ export const schema = Joi.object({
       'string.empty': 'This property is required according to the Open Graph protocol.',
     }),
 
-  'og:image': Joi.string()
-    .required().messages({
+  'og:image': Joi.image()
+    .required()
+    .messages({
       'string.empty': 'This property is required according to the Open Graph protocol.',
     }),
 
@@ -36,7 +37,7 @@ export const schema = Joi.object({
   'og:video': Joi.string()
     .allow(''),
 
-  'og:image:url': Joi.string()
+  'og:image:url': Joi.image()
     .allow(''),
 
   'og:image:secure_url': Joi.string()

--- a/projects/@shared/views/open-graph/schema.js
+++ b/projects/@shared/views/open-graph/schema.js
@@ -1,159 +1,177 @@
-const openGraphSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'og:title': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Open Graph protocol.',
+    }),
+
+  'og:type': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Open Graph protocol.',
+    }),
+
+  'og:image': Joi.string()
+    .required().messages({
+      'string.empty': 'This property is required according to the Open Graph protocol.',
+    }),
+
+  'og:url': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Open Graph protocol.',
+    }),
+
+  'og:description': Joi.string()
+    .allow(''),
+
+  'og:locale': Joi.string()
+    .allow(''),
+
+  'og:site_name': Joi.string()
+    .allow(''),
+
+  'og:video': Joi.string()
+    .allow(''),
+
+  'og:image:url': Joi.string()
+    .allow(''),
+
+  'og:image:secure_url': Joi.string()
+    .allow(''),
+
+  'og:image:type': Joi.string()
+    .allow(''),
+
+  'og:image:width': Joi.string()
+    .allow(''),
+
+  'og:image:height': Joi.string()
+    .allow(''),
+
+  'og:image:alt': Joi.string()
+    .allow(''),
+
+  'og:video:url': Joi.string()
+    .allow(''),
+
+  'og:video:secure_url': Joi.string()
+    .allow(''),
+
+  'og:video:type': Joi.string()
+    .allow(''),
+
+  'og:video:width': Joi.string()
+    .allow(''),
+
+  'og:video:height': Joi.string()
+    .allow(''),
+
+  'og:video:alt': Joi.string()
+    .allow(''),
+});
+
+
+export const info = {
   'og:title': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Open Graph protocol.',
-    },
-    meta: {
-      info: 'The <code>og:title</code> element defines the title of your object as it should appear within the graph.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:title</code> element defines the title of your object as it should appear within the graph.',
+    link: 'https://ogp.me/',
   },
 
   'og:type': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Open Graph protocol.',
-    },
-    meta: {
-      info: 'The <code>og:type</code> element defines the type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:type</code> element defines the type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.',
+    link: 'https://ogp.me/',
   },
 
   'og:image': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Open Graph protocol.',
-    },
-    meta: {
-      info: 'The <code>og:image</code> element defines an image URL which should represent your object within the graph.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:image</code> element defines an image URL which should represent your object within the graph.',
+    link: 'https://ogp.me/',
   },
 
   'og:url': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Open Graph protocol.',
-    },
-    meta: {
-      info: 'The <code>og:url</code> element defines the canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/"',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:url</code> element defines the canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/"',
+    link: 'https://ogp.me/',
   },
 
   'og:description': {
-    meta: {
-      info: 'The <code>og:description</code> element defines a one to two sentence description of your object.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:description</code> element defines a one to two sentence description of your object.',
+    link: 'https://ogp.me/',
   },
 
   'og:locale': {
-    meta: {
-      info: 'The <code>og:locale</code> element defines the locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:locale</code> element defines the locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.',
+    link: 'https://ogp.me/',
   },
 
   'og:site_name': {
-    meta: {
-      info: 'The <code>og:site_name</code> element defines if your object is part of a larger web site, the name which should be displayed for the overall site. e.g., "IMDb".',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:site_name</code> element defines if your object is part of a larger web site, the name which should be displayed for the overall site. e.g., "IMDb".',
+    link: 'https://ogp.me/',
   },
 
   'og:video': {
-    meta: {
-      info: 'The <code>og:site_name</code> element defines a URL to a video file that complements this object.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The <code>og:site_name</code> element defines a URL to a video file that complements this object.',
+    link: 'https://ogp.me/',
   },
 
   'og:image:url': {
-    meta: {
-      info: 'Identical to <code>og:image</code> property. The <code>og:image:url</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'Identical to <code>og:image</code> property. The <code>og:image:url</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:image:secure_url': {
-    meta: {
-      info: 'An alternate url to use if the webpage requires HTTPS. The <code>og:image:secure_url</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'An alternate url to use if the webpage requires HTTPS. The <code>og:image:secure_url</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:image:type': {
-    meta: {
-      info: 'A MIME type for this image. The <code>og:image:type</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'A MIME type for this image. The <code>og:image:type</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:image:width': {
-    meta: {
-      info: 'The number of pixels wide. The <code>og:image:width</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The number of pixels wide. The <code>og:image:width</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:image:height': {
-    meta: {
-      info: 'The number of pixels high. The <code>og:image:height</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The number of pixels high. The <code>og:image:height</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:image:alt': {
-    meta: {
-      info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:video:url': {
-    meta: {
-      info: 'Identical to <code>og:video</code> property. The <code>og:video:url</code> is an optional structured property for <code>og:video</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'Identical to <code>og:video</code> property. The <code>og:video:url</code> is an optional structured property for <code>og:video</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:video:secure_url': {
-    meta: {
-      info: 'An alternate url to use if the webpage requires HTTPS. The <code>og:video:secure_url</code> is an optional structured property for <code>og:video</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'An alternate url to use if the webpage requires HTTPS. The <code>og:video:secure_url</code> is an optional structured property for <code>og:video</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:video:type': {
-    meta: {
-      info: 'A MIME type for this video. The <code>og:video:type</code> is an optional structured property for <code>og:video</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'A MIME type for this video. The <code>og:video:type</code> is an optional structured property for <code>og:video</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:video:width': {
-    meta: {
-      info: 'The number of pixels wide. The <code>og:video:width</code> is an optional structured property for <code>og:video</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The number of pixels wide. The <code>og:video:width</code> is an optional structured property for <code>og:video</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:video:height': {
-    meta: {
-      info: 'The number of pixels high. The <code>og:video:height</code> is an optional structured property for <code>og:video</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'The number of pixels high. The <code>og:video:height</code> is an optional structured property for <code>og:video</code>.',
+    link: 'https://ogp.me/',
   },
 
   'og:video:alt': {
-    meta: {
-      info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
-      link: 'https://ogp.me/',
-    },
+    info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
   },
 };
-
-export default openGraphSchema;


### PR DESCRIPTION
Open Graph view now uses new Joi validation.

## What change(s) were made
- The `open-graph.view.vue` view now uses the new Joi validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/1F3Zl0xi](https://trello.com/c/1F3Zl0xi)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
