### PR TITLE
Feat/open search validation

### DIFF
--- a/projects/@shared/components/properties-item-new.vue
+++ b/projects/@shared/components/properties-item-new.vue
@@ -161,7 +161,7 @@ export default {
       return this.errors?.[0]?.message.trim();
     },
     errors() {
-      return this.validation.errors.filter(item => (item.context.key === this.term));
+      return this.validation.errors.filter(item => (item.path[0] === this.term));
     },
     hasErrors() {
       return this.validation.errors && this.errors.length;
@@ -194,7 +194,7 @@ export default {
       return this.warnings?.[0]?.message.trim();
     },
     warnings() {
-      return this.validation.warnings.filter(item => (item.context.key === this.term));
+      return this.validation.warnings.filter(item => (item.path[0] === this.term));
     },
   },
 };

--- a/projects/@shared/lib/validate-data.js
+++ b/projects/@shared/lib/validate-data.js
@@ -23,8 +23,7 @@ const transformData = data => {
       */
       if (type === 'image') {
         const { width, height } = await getImageDimensions(image.url);
-        const value = image.url ? { url: image.url, width, height } : image.url;
-        return { ...item, value };
+        return { ...item, value: { url: image.url, width, height } };
       }
 
       return item;

--- a/projects/@shared/lib/validator/extensions/image.js
+++ b/projects/@shared/lib/validator/extensions/image.js
@@ -29,7 +29,7 @@ const image = joi => ({
           return { value, warn: helpers.warn('image.minWidth', { width: args.width }) };
         }
 
-        return { value };
+        return value;
       },
     },
     maxWidth: {
@@ -49,7 +49,7 @@ const image = joi => ({
           return { value, warn: helpers.warn('image.maxWidth', { width: args.width }) };
         }
 
-        return { value };
+        return value;
       },
     },
     minHeight: {
@@ -69,7 +69,7 @@ const image = joi => ({
           return { value, warn: helpers.warn('image.minHeight', { height: args.height }) };
         }
 
-        return { value };
+        return value;
       },
     },
     maxHeight: {
@@ -89,7 +89,7 @@ const image = joi => ({
           return { value, warn: helpers.warn('image.maxHeight', { height: args.height }) };
         }
 
-        return { value };
+        return value;
       },
     },
     minDimensions: {
@@ -115,7 +115,7 @@ const image = joi => ({
           return { value, warn: helpers.warn('image.minDimensions', { width: args.width, height: args.height }) };
         }
 
-        return { value };
+        return value;
       },
     },
     maxDimensions: {
@@ -141,7 +141,7 @@ const image = joi => ({
           return { value, warn: helpers.warn('image.maxDimensions', { width: args.width, height: args.height }) };
         }
 
-        return { value };
+        return value;
       },
     },
   },

--- a/projects/@shared/views/open-search/open-search.view.vue
+++ b/projects/@shared/views/open-search/open-search.view.vue
@@ -111,7 +111,7 @@ export default {
       },
       {
         term: 'urls',
-        value: urls.value && urls.value.length ? formatUrlsObject(urls.value) : [],
+        value: urls.value?.length ? formatUrlsObject(urls.value) : [],
         type: 'urls',
       },
       {

--- a/projects/@shared/views/open-search/open-search.view.vue
+++ b/projects/@shared/views/open-search/open-search.view.vue
@@ -17,16 +17,17 @@
     </panel-section>
     <panel-section v-if="hasOpenSearchFile" title="Tags">
       <properties-list>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
           :image="item.image"
           :type="item.type"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -46,13 +47,14 @@ import { computed, ref, onMounted, watch } from 'vue';
 import createAbsoluteUrl from '@shared/lib/create-absolute-url';
 import { findLinkHref, findXMLElement } from '@shared/lib/find-meta';
 import getTheme from '@shared/lib/theme';
-import schema from './schema';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link.vue';
 import PanelSection from '@shared/components/panel-section.vue';
 import PreviewIframe from '@shared/components/preview-iframe';
 import PropertiesList from '@shared/components/properties-list.vue';
-import PropertiesItem from '@shared/components/properties-item.vue';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import WarningIcon from '@shared/assets/icons/warning.svg';
 
 export default {
@@ -64,6 +66,7 @@ export default {
   },
 
   setup: props => {
+    const validation = ref({});
     const fileContent = ref('');
     const hasOpenSearchFile = computed(() => fileUrl.value && fileContent.value);
     const metaTagValue = computed(() => findLinkHref(props.headData.head, 'search'));
@@ -148,10 +151,19 @@ export default {
         });
     };
 
-    watch(fileUrl, value => {
+    const getTooltipInfo = term => (info[term] ?? {});
+
+    watch(fileContent, (value, oldValue) => {
+      if (value !== oldValue) {
+        validate(metaData.value, schema)
+          .then(result => validation.value = result);
+      }
+    });
+
+    watch(fileUrl, (value, oldValue) => {
       fileContent.value = '';
 
-      if (value) {
+      if (value !== oldValue) {
         getFileContent(value);
       }
     });
@@ -160,6 +172,7 @@ export default {
 
     return {
       fileContent,
+      getTooltipInfo,
       hasOpenSearchFile,
       metaTagValue,
       previewUrl,
@@ -170,14 +183,14 @@ export default {
       image,
       inputEncoding,
       metaData,
-      schema,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
     PreviewIframe,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
     WarningIcon,
   },

--- a/projects/@shared/views/open-search/open-search.view.vue
+++ b/projects/@shared/views/open-search/open-search.view.vue
@@ -111,7 +111,7 @@ export default {
       },
       {
         term: 'urls',
-        value: formatUrlsObject(urls.value),
+        value: urls.value && urls.value.length ? formatUrlsObject(urls.value) : [],
         type: 'urls',
       },
       {

--- a/projects/@shared/views/open-search/schema.js
+++ b/projects/@shared/views/open-search/schema.js
@@ -1,51 +1,61 @@
-const openSearchMetaSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'shortname': Joi.string()
+    .max(16)
+    .required()
+    .messages({
+      'string.max': 'Avoid 16 characters or more.',
+    }),
+
+  'description': Joi.string()
+    .max(1024)
+    .allow(null)
+    .messages({
+      'string.max': 'Avoid 1024 characters or more.',
+    }),
+
+  'urls': Joi.array()
+    .items(
+      Joi.object({
+        attributes: Joi.object().required(),
+        url: Joi.string().required(),
+      })
+    )
+    .allow(null),
+
+  'image': Joi.image()
+    .minDimensions(16, 16)
+    .maxDimensions(64, 64)
+    .allow(null),
+
+  'input-encoding': Joi.string()
+    .allow(null),
+});
+
+export const info = {
   'shortname': {
-    required: true,
-    message: {
-      required: 'The shortname element is required.',
-      'max-characters': 'Avoid 16 characters or more.',
-    },
-    meta: {
-      info: 'A short name for the search engine. It must be <strong>16 or fewer characters</strong> of plain text, with no HTML or other markup.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
-    },
-    'max-characters': 16,
+    info: 'A short name for the search engine. It must be <strong>16 or fewer characters</strong> of plain text, with no HTML or other markup.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
   },
 
   'description': {
-    message: {
-      'max-characters': 'Avoid 1024 characters or more.',
-    },
-    meta: {
-      info: 'A brief description of the search engine. It must be <strong>1024 or fewer characters</strong> of plain text, with no HTML or other markup.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
-    },
-    'max-characters': 1024,
+    info: 'A brief description of the search engine. It must be <strong>1024 or fewer characters</strong> of plain text, with no HTML or other markup.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
   },
 
   'urls': {
-    message: {
-      required: 'The url element is required.',
-    },
-    meta: {
-      info: 'Describes the URL or URLs to use for the search. The template <code>attribute</code> indicates the base URL for the search query.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
-    },
+    info: 'Describes the URL or URLs to use for the search. The template <code>attribute</code> indicates the base URL for the search query.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
   },
 
   'image': {
-    meta: {
-      info: 'URI of an icon for the search engine. When possible, include a 16×16 image of type <code>image/x-icon</code> (such as <code>/favicon.ico</code>) and a 64×64 image of type <code>image/jpeg</code> or <code>image/png</code>.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
-    },
+    info: 'URI of an icon for the search engine. When possible, include a 16×16 image of type <code>image/x-icon</code> (such as <code>/favicon.ico</code>) and a 64×64 image of type <code>image/jpeg</code> or <code>image/png</code>.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
   },
 
   'input-encoding': {
-    meta: {
-      info: 'The character encoding to use when submitting input to the search engine.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
-    },
+    info: 'The character encoding to use when submitting input to the search engine.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
   },
 };
-
-export default openSearchMetaSchema;


### PR DESCRIPTION
Open Search view now uses new Joi validation.

## What change(s) were made
- The `open-search.view.vue` view now uses the new Joi validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/pmayMKMv](https://trello.com/c/pmayMKMv)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
