### PR TITLE
Feat/search meta validation

### DIFF
--- a/projects/@shared/lib/validator/extensions/language.js
+++ b/projects/@shared/lib/validator/extensions/language.js
@@ -19,7 +19,7 @@ const language = joi => ({
       validate(value, helpers) {
         const validCode = validateCountryCodes().includes(value);
         if (!validCode) {
-          return { value, errors: helpers.error('language.countryCode') };
+          return helpers.error('language.countryCode');
         }
 
         return value;

--- a/projects/@shared/lib/validator/extensions/language.js
+++ b/projects/@shared/lib/validator/extensions/language.js
@@ -9,13 +9,23 @@ const language = joi => ({
   type: 'language',
   base: joi.string(),
   messages: {
-    'language.base': 'The {{#label}} value should meet the bcp47 standards.',
+    'language.countryCode': 'The {{#label}} value should meet the bcp47 standards.',
   },
-  validate(value, helpers) {
-    if (!validateCountryCodes().includes(value)) {
-      return { value, errors: helpers.error('language.base') };
+  rules: {
+    countryCode: {
+      method() {
+        return this.$_addRule({ name: 'countryCode' });
+      },
+      validate(value, helpers) {
+        const validCode = validateCountryCodes().includes(value);
+        if (!validCode) {
+          return { value, errors: helpers.error('language.countryCode') };
+        }
+
+        return value;
+      },
     }
-  },
+  }
 });
 
 export default language;

--- a/projects/@shared/lib/validator/extensions/language.js
+++ b/projects/@shared/lib/validator/extensions/language.js
@@ -24,8 +24,8 @@ const language = joi => ({
 
         return value;
       },
-    }
-  }
+    },
+  },
 });
 
 export default language;

--- a/projects/@shared/lib/validator/extensions/search.js
+++ b/projects/@shared/lib/validator/extensions/search.js
@@ -1,0 +1,89 @@
+// source: https://developers.google.com/search/docs/advanced/crawling/special-tags
+const DEFAULT_ROBOT_VALUES = [ 'index', 'follow' ];
+const VALID_GOOGLE_SETTINGS = [ 'nositelinkssearchbox', 'notranslate', 'nopagereadaloud' ];
+const VALID_ROBOT_VALUES = [
+  'all',
+  'follow',
+  'index',
+  'max-image-preview',
+  'max-snippet',
+  'max-video-preview',
+  'noarchive',
+  'nocache',
+  'nofollow',
+  'noimageindex',
+  'noindex',
+  'none',
+  'noodp',
+  'noodyp',
+  'nosnippet',
+  'noydir',
+  'unavailable_after',
+];
+
+function hasValidGoogleSettings(value) {
+  return VALID_GOOGLE_SETTINGS.includes(value);
+}
+
+function hasValidRobotValues(value) {
+  const arrayOfValues = value.replace(/ /g, '').split(',');
+
+  return arrayOfValues.every(value => {
+    return VALID_ROBOT_VALUES.includes(value);
+  });
+}
+
+function hasDefaultRobotValues(value) {
+  const arrayOfValues = value.replace(/ /g, '').split(',');
+
+  return arrayOfValues.some(value => {
+    return DEFAULT_ROBOT_VALUES.includes(value);
+  });
+}
+
+/**
+ * Search, crawling and advanced SEO related validation.
+ *
+ * @param {*} joi - Extended Joi instance.
+ */
+const search = joi => ({
+  type: 'search',
+  base: joi.string(),
+  messages: {
+    'search.invalidSetting': 'This is not a valid tag value that Google understands.',
+    'search.invalidRobots': 'One or more values are not valid to control the behavior of search engine crawling and indexing.',
+    'search.defaultRobots': '"index" and "follow" are default values and don\'t need to be specified.',
+  },
+  rules: {
+    robots: {
+      method() {
+        return this.$_addRule({ name: 'robots' });
+      },
+      validate(value, helpers) {
+        if (!hasValidRobotValues(value)) {
+          return helpers.error('search.invalidRobots');
+        }
+
+        if (hasDefaultRobotValues(value)) {
+          return { value, warn: helpers.warn('search.defaultRobots') };
+        }
+
+        return value;
+      },
+    },
+    googleSetting: {
+      method() {
+        return this.$_addRule({ name: 'googleSetting' });
+      },
+      validate(value, helpers) {
+        if (!hasValidGoogleSettings(value)) {
+          return helpers.error('search.invalidSetting');
+        }
+
+        return value;
+      },
+    },
+  },
+});
+
+export default search;

--- a/projects/@shared/lib/validator/extensions/viewport.js
+++ b/projects/@shared/lib/validator/extensions/viewport.js
@@ -57,7 +57,7 @@ const viewport = joi => ({
   },
   validate(value, helpers) {
     if (!hasValidViewportKeys(value)) {
-      return { value, errors: helpers.error('viewport.keys') };
+      return helpers.error('viewport.keys');
     }
 
     if (!hasValidViewportContent(value)) {

--- a/projects/@shared/lib/validator/extensions/words.js
+++ b/projects/@shared/lib/validator/extensions/words.js
@@ -8,7 +8,8 @@ const words = joi => ({
   base: joi.string(),
   messages: {
     'words.base': '{{#label}} must have at least 1 word',
-    'words.minWords': '{{#label}} must be at least {{#words}} words or more.',
+    'words.minWords': '{{#label}} should avoid having {{#words}} words or less.',
+    'words.maxWords': '{{#label}} should avoid having {{#words}} words or more.',
   },
   validate(value, helpers) {
     // Base validation regardless of the rules applied.
@@ -34,11 +35,35 @@ const words = joi => ({
         const trimmedValue = (value && value.length) ? value.trim() : value;
         const array = trimmedValue.length ? trimmedValue.split(' ') : trimmedValue;
 
-        if (array && array.length > args.words) {
-          return array;
+        if (array && array.length < args.words) {
+          return { value, warn: helpers.warn('words.minWords', { words: args.words }) };
         }
 
-        return { value, warn: helpers.warn('words.minWords', { words: args.words }) };
+        return value;
+      },
+    },
+    maxWords: {
+      alias: 'max',
+      method(words) {
+        return this.$_addRule({ name: 'maxWords', args: { words } });
+      },
+      args: [
+        {
+          name: 'words',
+          ref: true,
+          assert: value => typeof value === 'number' && !isNaN(value),
+          message: 'must be a number',
+        },
+      ],
+      validate(value, helpers, args) {
+        const trimmedValue = (value && value.length) ? value.trim() : value;
+        const array = trimmedValue.length ? trimmedValue.split(' ') : trimmedValue;
+
+        if (array && array.length > args.words) {
+          return { value, warn: helpers.warn('words.maxWords', { words: args.words }) };
+        }
+
+        return value;
       },
     },
   },

--- a/projects/@shared/lib/validator/extensions/words.js
+++ b/projects/@shared/lib/validator/extensions/words.js
@@ -13,7 +13,7 @@ const words = joi => ({
   },
   validate(value, helpers) {
     // Base validation regardless of the rules applied.
-    if (value && value.length <= 1) {
+    if (value?.length <= 1) {
       return { value, errors: helpers.error('words.base') };
     }
   },
@@ -32,10 +32,10 @@ const words = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        const trimmedValue = (value && value.length) ? value.trim() : value;
+        const trimmedValue = value?.length ? value.trim() : value;
         const array = trimmedValue.length ? trimmedValue.split(' ') : trimmedValue;
 
-        if (array && array.length < args.words) {
+        if (array?.length < args.words) {
           return { value, warn: helpers.warn('words.minWords', { words: args.words }) };
         }
 
@@ -56,10 +56,10 @@ const words = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        const trimmedValue = (value && value.length) ? value.trim() : value;
+        const trimmedValue = value?.length ? value.trim() : value;
         const array = trimmedValue.length ? trimmedValue.split(' ') : trimmedValue;
 
-        if (array && array.length > args.words) {
+        if (array?.length > args.words) {
           return { value, warn: helpers.warn('words.maxWords', { words: args.words }) };
         }
 

--- a/projects/@shared/lib/validator/index.js
+++ b/projects/@shared/lib/validator/index.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 import image from './extensions/image';
 import language from './extensions/language';
+import search from './extensions/search';
 import viewport from './extensions/viewport';
 import words from './extensions/words';
 
@@ -9,6 +10,7 @@ let validator = Joi;
 const extensions = [
   joi => image(joi),
   joi => language(joi),
+  joi => search(joi),
   joi => viewport(joi),
   joi => words(joi),
 ];

--- a/projects/@shared/views/meta/schema.js
+++ b/projects/@shared/views/meta/schema.js
@@ -3,7 +3,10 @@ import Joi from '../../lib/validator';
 export const schema = Joi.object({
   'title': Joi.words()
     .min(3)
-    .required(),
+    .required()
+    .messages({
+      'words.minWords': 'Avoid one- or two-word titles.',
+    }),
 
   'lang': Joi.language()
     .required(),
@@ -20,7 +23,11 @@ export const schema = Joi.object({
     .allow(''),
 
   'description': Joi.string()
-    .allow(''),
+    .max(150)
+    .allow('')
+    .messages({
+      'string.max': 'Try to limit the description to 150 characters.',
+    }),
 
   'theme-color': Joi.string()
     .pattern(new RegExp('^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6})$', 'i')) // Match #abc, #abcd shorthands and #abcdef.

--- a/projects/@shared/views/meta/schema.js
+++ b/projects/@shared/views/meta/schema.js
@@ -9,6 +9,7 @@ export const schema = Joi.object({
     }),
 
   'lang': Joi.language()
+    .countryCode()
     .required(),
 
   'charset': Joi.string()

--- a/projects/@shared/views/search-meta/schema.js
+++ b/projects/@shared/views/search-meta/schema.js
@@ -1,79 +1,94 @@
-const searchMetaSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'title': Joi.words()
+    .min(3)
+    .required()
+    .messages({
+      'words.minWords': 'Avoid one- or two-word titles.',
+    }),
+
+  'description': Joi.string()
+    .max(150)
+    .allow('')
+    .messages({
+      'string.max': 'Try to limit the description to 150 characters.',
+    }),
+
+  'search': Joi.string()
+    .allow(''),
+
+  'canonical': Joi.string()
+    .allow(''),
+
+  'robots': Joi.search()
+    .robots()
+    .allow(''),
+
+  'googlebot': Joi.string()
+    .allow(''),
+
+  'google': Joi.string()
+    .allow(''),
+
+  'google-site-verification': Joi.string()
+    .allow(''),
+
+  'msvalidate.01': Joi.string()
+    .allow(''),
+
+  'yandex-verification': Joi.string()
+    .allow(''),
+});
+
+export const info = {
   'title': {
-    required: true,
-    message: {
-      required: 'The title element is required.',
-      'descriptive-words': 'Avoid one- or two word titles.',
-    },
-    meta: {
-      info: 'The HTML <code>title</code> element defines the document\'s title that is shown in a browser\'s title bar or a page\'s tab.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title',
-    },
-    'descriptive-words': 3,
+    info: 'The HTML <code>title</code> element defines the document\'s title that is shown in a browser\'s title bar or a page\'s tab.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title',
   },
 
   'description': {
-    meta: {
-      info: 'Short description of the document (limit to 150 characters).',
-      link: 'https://htmlhead.dev/#meta',
-    },
+    info: 'Short description of the document (limit to 150 characters).',
+    link: 'https://htmlhead.dev/#meta',
   },
 
   'search': {
-    meta: {
-      info: 'Web sites with search plugins can advertise them so a browser or other client application can use that search engine.',
-      link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
-    },
+    info: 'Web sites with search plugins can advertise them so a browser or other client application can use that search engine.',
+    link: 'https://developer.mozilla.org/en-US/docs/Web/OpenSearch',
   },
 
   'canonical': {
-    meta: {
-      info: 'A canonical link is used to prevent duplicate content issues by specifying the "canonical" or "preferred" version of a web page as part of search engine optimization.',
-      link: 'https://en.wikipedia.org/wiki/Canonical_link_element',
-    },
+    info: 'A canonical link is used to prevent duplicate content issues by specifying the "canonical" or "preferred" version of a web page as part of search engine optimization.',
+    link: 'https://en.wikipedia.org/wiki/Canonical_link_element',
   },
 
   'robots': {
-    meta: {
-      info: 'Control the behavior of crawling and indexing for all search engines.',
-      link: 'https://htmlhead.dev/#meta',
-    },
+    info: 'Control the behavior of crawling and indexing for all search engines.',
+    link: 'https://htmlhead.dev/#meta',
   },
 
   'googlebot': {
-    meta: {
-      info: 'Control the behavior of crawling and indexing for Google specific search engine.',
-      link: 'https://htmlhead.dev/#meta',
-    },
+    info: 'Control the behavior of crawling and indexing for Google specific search engine.',
+    link: 'https://htmlhead.dev/#meta',
   },
 
   'google': {
-    meta: {
-      info: 'Give specific instructions to help control how your site\'s pages will appear in Google Search.',
-      link: 'https://support.google.com/webmasters/answer/79812',
-    },
+    info: 'Give specific instructions to help control how your site\'s pages will appear in Google Search.',
+    link: 'https://support.google.com/webmasters/answer/79812',
   },
 
   'google-site-verification': {
-    meta: {
-      info: 'Used to verify site ownership using the Google Search Console.',
-      link: 'https://support.google.com/webmasters/answer/9008080',
-    },
+    info: 'Used to verify site ownership using the Google Search Console.',
+    link: 'https://support.google.com/webmasters/answer/9008080',
   },
 
   'msvalidate.01': {
-    meta: {
-      info: 'Used to verify site ownership using the Bing Webmaster Center.',
-      link: 'https://www.bing.com/webmaster/help/getting-started-checklist-66a806de',
-    },
+    info: 'Used to verify site ownership using the Bing Webmaster Center.',
+    link: 'https://www.bing.com/webmaster/help/getting-started-checklist-66a806de',
   },
 
   'yandex-verification': {
-    meta: {
-      info: 'Used to verify site ownership using the Yandex Webmaster tools.',
-      link: 'https://yandex.com/support/webmaster/service/rights.html',
-    },
+    info: 'Used to verify site ownership using the Yandex Webmaster tools.',
+    link: 'https://yandex.com/support/webmaster/service/rights.html',
   },
 };
-
-export default searchMetaSchema;

--- a/projects/@shared/views/search-meta/schema.js
+++ b/projects/@shared/views/search-meta/schema.js
@@ -25,16 +25,19 @@ export const schema = Joi.object({
     .robots()
     .allow(''),
 
-  'googlebot': Joi.string()
+  'googlebot': Joi.search()
+    .robots()
     .allow(''),
 
-  'google': Joi.string()
+  'google': Joi.search()
+    .googleSetting()
     .allow(''),
 
   'google-site-verification': Joi.string()
     .allow(''),
 
   'msvalidate.01': Joi.string()
+    .length(32)
     .allow(''),
 
   'yandex-verification': Joi.string()
@@ -69,7 +72,7 @@ export const info = {
 
   'googlebot': {
     info: 'Control the behavior of crawling and indexing for Google specific search engine.',
-    link: 'https://htmlhead.dev/#meta',
+    link: 'https://developers.google.com/search/docs/advanced/crawling/special-tags',
   },
 
   'google': {

--- a/projects/@shared/views/search-meta/search-meta.view.vue
+++ b/projects/@shared/views/search-meta/search-meta.view.vue
@@ -2,16 +2,17 @@
   <div class="search-meta">
     <panel-section title="Properties">
       <properties-list>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
           :type="item.type"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
           :required="item.required"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -32,14 +33,15 @@
 </template>
 
 <script>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import createAbsoluteUrl from '@shared/lib/create-absolute-url';
 import { findLinkHref, findMetaContent } from '@shared/lib/find-meta';
-import schema from './schema';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import PanelSection from '@shared/components/panel-section';
 import ExternalLink from '@shared/components/external-link';
-import PropertiesItem from '@shared/components/properties-item';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import PropertiesList from '@shared/components/properties-list';
 
 export default {
@@ -51,6 +53,7 @@ export default {
   },
 
   setup: props => {
+    const validation = ref({});
     const metaData = computed(() => {
       const { head } = props.headData;
       return [
@@ -103,16 +106,21 @@ export default {
     });
 
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
+    const getTooltipInfo = term => (info[term] ?? {});
+
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
 
     return {
+      getTooltipInfo,
       metaData,
-      schema,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
   },
 };


### PR DESCRIPTION
Search Meta view now uses new Joi validation.

## What change(s) were made
- The `search-meta.view.vue` view now uses the new Joi validation.
- New `search` Joi extension.

Also:
- `countryCode` validation now follows Joi conventions.
- `helpers.error` is now returned according to Joi conventions.
- New `maxWords` to check maximum number of words allowed.
- Improved `meta` validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/F2DkejBc](https://trello.com/c/F2DkejBc)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
