### PR TITLE
Feat/slack validation

### DIFF
--- a/projects/@shared/views/facebook/facebook.view.vue
+++ b/projects/@shared/views/facebook/facebook.view.vue
@@ -228,7 +228,7 @@ export default {
     const propertyValue = propName =>
       findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
 
-    watch(og.value.image, (value, oldValue) => {
+    watch(() => og.value.image, (value, oldValue) => {
       if (value !== oldValue) {
         getImageDimensions();
       }

--- a/projects/@shared/views/linkedin/linkedin.view.vue
+++ b/projects/@shared/views/linkedin/linkedin.view.vue
@@ -132,7 +132,7 @@ export default {
     const propertyValue = propName =>
       findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
 
-    watch(og.value.image, (value, oldValue) => {
+    watch(() => og.value.image, (value, oldValue) => {
       if (value !== oldValue) {
         getImageDimensions();
       }

--- a/projects/@shared/views/slack/schema.js
+++ b/projects/@shared/views/slack/schema.js
@@ -1,89 +1,97 @@
-const slackSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'og:title': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required for rich links on Slack.',
+    }),
+
+  'og:type': Joi.string()
+    .allow(''),
+
+  'og:description': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required for rich links on Slack.',
+    }),
+
+  'og:site_name': Joi.string()
+    .allow(''),
+
+  'og:image': Joi.image()
+    .required()
+    .messages({
+      'string.empty': 'This property is required for rich links on Slack.',
+    }),
+
+  'og:url': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required for rich links on Slack.',
+    }),
+
+  'twitter:label1': Joi.string()
+    .allow(''),
+
+  'twitter:data1': Joi.string()
+    .allow(''),
+
+  'twitter:label2': Joi.string()
+    .allow(''),
+
+  'twitter:data2': Joi.string()
+    .allow(''),
+});
+
+export const info = {
   'og:title': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on Slack.',
-    },
-    meta: {
-      info: 'The <code>og:title</code> element defines the title of your rich link.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>og:title</code> element defines the title of your rich link.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'og:type': {
-    meta: {
-      info: 'The <code>og:type</code> element defines the type of content, whether it’s an article, video, or rich media.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>og:type</code> element defines the type of content, whether it’s an article, video, or rich media.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'og:description': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on Slack.',
-    },
-    meta: {
-      info: 'The <code>og:description</code> element defines the description of your rich link.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>og:description</code> element defines the description of your rich link.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'og:site_name': {
-    meta: {
-      info: 'The <code>og:site_name</code> element defines the name which should be displayed for the overall site. e.g., "IMDb".',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>og:site_name</code> element defines the name which should be displayed for the overall site. e.g., "IMDb".',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'og:image': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on Slack.',
-    },
-    meta: {
-      info: 'The <code>og:image</code> element defines the image of your rich link.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>og:image</code> element defines the image of your rich link.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'og:url': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on Slack.',
-    },
-    meta: {
-      info: 'The <code>og:url</code> element defines the canonical URL of your rich link.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>og:url</code> element defines the canonical URL of your rich link.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'twitter:label1': {
-    meta: {
-      info: 'The <code>twitter:label1</code> needs to be paired with <code>twitter:data1</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>twitter:label1</code> needs to be paired with <code>twitter:data1</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'twitter:data1': {
-    meta: {
-      info: 'The <code>twitter:data1</code> needs to be paired with <code>twitter:label1</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>twitter:data1</code> needs to be paired with <code>twitter:label1</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'twitter:label2': {
-    meta: {
-      info: 'The <code>twitter:label2</code> needs to be paired with <code>twitter:data2</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>twitter:label2</code> needs to be paired with <code>twitter:data2</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 
   'twitter:data2': {
-    meta: {
-      info: 'The <code>twitter:data2</code> needs to be paired with <code>twitter:label2</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
-      link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
-    },
+    info: 'The <code>twitter:data2</code> needs to be paired with <code>twitter:label2</code>. They can be used to display prices, inventory, categories in a nicely formatted way. Those data fields will work on any Twitter card type in Slack, even though Twitter itself will ignore them in all but Product type.',
+    link: 'https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254',
   },
 };
-
-export default slackSchema;

--- a/projects/@shared/views/twitter/twitter.view.vue
+++ b/projects/@shared/views/twitter/twitter.view.vue
@@ -302,13 +302,13 @@ export default {
         .then(dimensions => imageDimensions.value = dimensions);
     };
 
-    watch(og.value.image, (value, oldValue) => {
+    watch(() => og.value.image, (value, oldValue) => {
       if (value !== oldValue) {
         getImageDimensions('og:image');
       }
     });
 
-    watch(twitter.value.image, (value, oldValue) => {
+    watch(() => og.value.image, (value, oldValue) => {
       if (value !== oldValue) {
         getImageDimensions('twitter:image');
       }


### PR DESCRIPTION
Slack view now uses new Joi validation.

## What change(s) were made
- The `slack.view.vue` view now uses the new Joi validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/fmdZTxaO](https://trello.com/c/fmdZTxaO)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
