### PR TITLE
Feat/linkedin validation

### DIFF
--- a/projects/@shared/views/linkedin/linkedin.view.vue
+++ b/projects/@shared/views/linkedin/linkedin.view.vue
@@ -17,17 +17,18 @@
     </panel-section>
     <panel-section title="Properties">
       <properties-list>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
           :image="item.image"
           :type="item.type"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
           :required="item.required"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -52,12 +53,13 @@ import { computed, onMounted, ref, watch } from 'vue';
 import createAbsoluteUrl from '@shared/lib/create-absolute-url';
 import { findImageDimensions, findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
 import getTheme from '@shared/lib/theme';
-import schema from './schema';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link';
 import PanelSection from '@shared/components/panel-section';
 import PreviewIframe from '@shared/components/preview-iframe';
-import PropertiesItem from '@shared/components/properties-item';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import PropertiesList from '@shared/components/properties-list';
 
 export default {
@@ -69,6 +71,7 @@ export default {
   },
 
   setup: props => {
+    const validation = ref({});
     const imageDimensions = ref({ height: undefined, width: undefined });
     const hasRequiredData = computed(() => (
       Boolean(og.value.title) &&
@@ -129,6 +132,7 @@ export default {
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
     const getImageDimensions = () => findImageDimensions(props.headData.head, 'og:image')
       .then(dimensions => imageDimensions.value = dimensions);
+    const getTooltipInfo = term => (info[term] ?? {});
     const propertyValue = propName =>
       findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
 
@@ -140,19 +144,23 @@ export default {
 
     onMounted(() => getImageDimensions());
 
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
+
     return {
       hasRequiredData,
       og,
       previewUrl,
       metaData,
-      schema,
+      getTooltipInfo,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
     PreviewIframe,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
   },
 };

--- a/projects/@shared/views/linkedin/schema.js
+++ b/projects/@shared/views/linkedin/schema.js
@@ -1,65 +1,63 @@
-const linkedinSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'og:title':Joi.string()
+    .max(150)
+    .required()
+    .messages({
+      'string.max': 'Try to limit the description to 150 characters.',
+      'string.empty': 'This property is required according to LinkedIn Help.',
+    }),
+
+  'og:type': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to LinkedIn Help.',
+    }),
+
+  'og:image': Joi.image()
+    .minDimensions(1200, 627)
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to LinkedIn Help.',
+    }),
+
+  'og:description': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to LinkedIn Help.',
+    }),
+
+  'og:url': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to LinkedIn Help.',
+    }),
+});
+
+export const info = {
   'og:title': {
-    required: true,
-    message: {
-      required: 'This property is required according to LinkedIn Help.',
-      'max-characters': 'Avoid 150 characters or more.',
-    },
-    meta: {
-      info: 'The <code>og:title</code> element defines the title of your object.',
-      link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
-    },
-    'max-characters': 150,
+    info: 'The <code>og:title</code> element defines the title of your object.',
+    link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
   },
 
   'og:type': {
-    required: true,
-    message: {
-      required: 'This property is required according to LinkedIn Help.',
-    },
-    meta: {
-      info: 'The <code>og:type</code> element defines the type of content, whether it’s an article, video, or rich media.',
-      link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
-    },
+    info: 'The <code>og:type</code> element defines the type of content, whether it’s an article, video, or rich media.',
+    link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
   },
 
   'og:image': {
-    required: true,
-    message: {
-      required: 'This property is required according to LinkedIn Help.',
-      'image-min-size': 'Avoid images smaller than 1200x627 or less.',
-    },
-    'image-min-size': {
-      height: 627,
-      width: 1200,
-    },
-    meta: {
-      info: 'The <code>og:image</code> element defines an image URL which should represent your object.',
-      link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
-    },
+    info: 'The <code>og:image</code> element defines an image URL which should represent your object.',
+    link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
   },
 
   'og:description': {
-    required: true,
-    message: {
-      required: 'This property is required according to LinkedIn Help.',
-    },
-    meta: {
-      info: 'The <code>og:description</code> element defines a brief description of the content.',
-      link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
-    },
+    info: 'The <code>og:description</code> element defines a brief description of the content.',
+    link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
   },
 
   'og:url': {
-    required: true,
-    message: {
-      required: 'This property is required according to LinkedIn Help.',
-    },
-    meta: {
-      info: 'The <code>og:url</code> element defines the canonical URL of your object.',
-      link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
-    },
+    info: 'The <code>og:url</code> element defines the canonical URL of your object.',
+    link: 'https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin',
   },
 };
-
-export default linkedinSchema;

--- a/projects/web-app/src/style/overwrites.css
+++ b/projects/web-app/src/style/overwrites.css
@@ -1,34 +1,34 @@
 /* Style overwrites for the shared components used in the web-app */
 
-.panel-section .heading {
+.app .panel-section .heading {
   margin-bottom: 24px;
   color: var(--color-blue);
   font-weight: bold;
 }
 
-.properties-list .properties-item {
+.app .properties-list .properties-item {
   margin-bottom: 26px;
 }
 
-.properties-list .properties-item__terms {
+.app .properties-list .properties-item__terms {
   flex: 0 0 40%;
   max-width: 250px;
 }
 
-.properties-list .properties-item__value {
+.app .properties-list .properties-item__value {
   flex: 1 1 auto;
   max-width: none;
 }
 
-.properties-item__image {
+.app .properties-item__image {
   margin-bottom: 0;
 }
 
-.properties-item__value--image a {
+.app .properties-item__value--image a {
   font-size: 12px;
 }
 
-.properties-item__icon {
+.app .properties-item__icon {
   top: -2px;
   width: 20px;
   height: 20px;


### PR DESCRIPTION
LinkedIn view now uses new Joi validation.

## What change(s) were made
- The `linkedin.view.vue` view now uses the new Joi validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/ewIiHY1S](https://trello.com/c/ewIiHY1S)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
