### PR TITLE
Feat/twitter validation

### DIFF
--- a/projects/@shared/lib/validator/extensions/image.js
+++ b/projects/@shared/lib/validator/extensions/image.js
@@ -147,6 +147,19 @@ const image = joi => ({
         return value;
       },
     },
+    isRequired: {
+      alias: 'required',
+      method() {
+        return this.$_addRule({ name: 'isRequired' });
+      },
+      validate(value, helpers) {
+        if (!value?.height && !value?.width && helpers.schema.$_getRule('isRequired')) {
+          return helpers.error('any.required');
+        }
+
+        return value;
+      },
+    },
   },
 });
 

--- a/projects/@shared/lib/validator/extensions/image.js
+++ b/projects/@shared/lib/validator/extensions/image.js
@@ -28,7 +28,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value.width < args.width) {
+        if (value?.width && value.width < args.width) {
           return { value, warn: helpers.warn('image.minWidth', { width: args.width }) };
         }
 
@@ -48,7 +48,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value.width > args.width) {
+        if (value?.width && value.width > args.width) {
           return { value, warn: helpers.warn('image.maxWidth', { width: args.width }) };
         }
 
@@ -68,7 +68,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value.height < args.height) {
+        if (value?.height && value.height < args.height) {
           return { value, warn: helpers.warn('image.minHeight', { height: args.height }) };
         }
 
@@ -88,7 +88,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value.height > args.height) {
+        if (value?.height && value.height > args.height) {
           return { value, warn: helpers.warn('image.maxHeight', { height: args.height }) };
         }
 
@@ -114,7 +114,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value.height < args.height || value.width < args.width) {
+        if (value?.height && value?.width && (value.height < args.height || value.width < args.width)) {
           return { value, warn: helpers.warn('image.minDimensions', { width: args.width, height: args.height }) };
         }
 
@@ -140,7 +140,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value.height > args.height || value.width > args.width) {
+        if (value?.height && value?.width && (value.height > args.height || value.width > args.width)) {
           return { value, warn: helpers.warn('image.maxDimensions', { width: args.width, height: args.height }) };
         }
 

--- a/projects/@shared/lib/validator/extensions/image.js
+++ b/projects/@shared/lib/validator/extensions/image.js
@@ -28,7 +28,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value?.width && value.width < args.width) {
+        if (value?.width < args.width) {
           return { value, warn: helpers.warn('image.minWidth', { width: args.width }) };
         }
 
@@ -48,7 +48,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value?.width && value.width > args.width) {
+        if (value?.width < args.width) {
           return { value, warn: helpers.warn('image.maxWidth', { width: args.width }) };
         }
 
@@ -68,7 +68,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value?.height && value.height < args.height) {
+        if (value?.height < args.height) {
           return { value, warn: helpers.warn('image.minHeight', { height: args.height }) };
         }
 
@@ -88,7 +88,7 @@ const image = joi => ({
         },
       ],
       validate(value, helpers, args) {
-        if (value?.height && value.height > args.height) {
+        if (value?.height > args.height) {
           return { value, warn: helpers.warn('image.maxHeight', { height: args.height }) };
         }
 

--- a/projects/@shared/views/twitter/schema.js
+++ b/projects/@shared/views/twitter/schema.js
@@ -1,243 +1,263 @@
-const twitterSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'twitter:card': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:site': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:site:id': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:creator': Joi.string()
+    .allow(''),
+
+  'twitter:creator:id': Joi.string()
+    .allow(''),
+
+  'twitter:description': Joi.string()
+    .max(200)
+    .required()
+    .messages({
+      'string.max': 'Avoid 200 characters or more.',
+      'string.empty': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:title': Joi.string()
+    .max(70)
+    .required()
+    .messages({
+      'string.max': 'Avoid 70 characters or more.',
+      'string.empty': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:image': Joi.image()
+    .minDimensions(144, 144)
+    .maxDimensions(4096, 4096)
+    .required()
+    .messages({
+      'any.required': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:image:alt': Joi.string()
+    .max(420)
+    .required()
+    .messages({
+      'string.max': 'Avoid 420 characters or more.',
+      'string.empty': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'twitter:player': Joi.string()
+    .allow(''),
+
+  'twitter:player:width': Joi.string()
+    .allow(''),
+
+  'twitter:player:height': Joi.string()
+    .allow(''),
+
+  'twitter:player:stream': Joi.string()
+    .allow(''),
+
+  'twitter:app:id:iphone': Joi.string()
+    .allow(''),
+
+  'twitter:app:id:ipad': Joi.string()
+    .allow(''),
+
+  'twitter:app:id:googleplay': Joi.string()
+    .allow(''),
+
+  'twitter:app:url:iphone': Joi.string()
+    .allow(''),
+
+  'twitter:app:url:ipad': Joi.string()
+    .allow(''),
+
+  'twitter:app:url:googleplay': Joi.string()
+    .allow(''),
+
+  'twitter:app:country': Joi.string()
+    .allow(''),
+
+  'twitter:app:name:iphone': Joi.string()
+    .allow(''),
+
+  'twitter:app:name:ipad': Joi.string()
+    .allow(''),
+
+  'twitter:app:name:googleplay': Joi.string()
+    .allow(''),
+
+  'og:title': Joi.string()
+    .allow(''),
+
+  'og:type': Joi.string()
+    .allow(''),
+
+  'og:image': Joi.image()
+    .minDimensions(144, 144)
+    .maxDimensions(4096, 4096)
+    .required()
+    .messages({
+      'any.required': 'This property is required according to the Twitter documentation.',
+    }),
+
+  'og:url': Joi.string()
+    .allow(''),
+
+  'og:description': Joi.string()
+    .allow(''),
+});
+
+export const info = {
   'twitter:card': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-    },
-    meta: {
-      info: 'The <code>twitter:card</code> element defines the card type. If an <code>og:type</code>, <code>og:title</code> and <code>og:description</code> exist in the markup but <code>twitter:card</code> is absent, then a summary card may be rendered.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards',
-    },
+    info: 'The <code>twitter:card</code> element defines the card type. If an <code>og:type</code>, <code>og:title</code> and <code>og:description</code> exist in the markup but <code>twitter:card</code> is absent, then a summary card may be rendered.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards',
   },
 
   'twitter:site': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-    },
-    meta: {
-      info: 'The <code>twitter:site</code> element defines the @username of website. Either <code>twitter:site</code> or <code>twitter:site:id</code> is required.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>twitter:site</code> element defines the @username of website. Either <code>twitter:site</code> or <code>twitter:site:id</code> is required.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:site:id': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-    },
-    meta: {
-      info: 'The <code>twitter:site:id</code> element defines the @username of website. Either <code>twitter:site</code> or <code>twitter:site:id</code> is required.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>twitter:site:id</code> element defines the @username of website. Either <code>twitter:site</code> or <code>twitter:site:id</code> is required.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:creator': {
-    meta: {
-      info: 'The <code>twitter:creator</code> element defines the @username of content creator.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>twitter:creator</code> element defines the @username of content creator.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:creator:id': {
-    meta: {
-      info: 'The <code>twitter:creator:id</code> element defines the Twitter user ID of content creator.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>twitter:creator:id</code> element defines the Twitter user ID of content creator.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:description': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-      'max-characters': 'Avoid 200 characters or more.',
-    },
-    meta: {
-      info: 'The <code>twitter:description</code> element defines the description of content.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
-    'max-characters': 200,
+    info: 'The <code>twitter:description</code> element defines the description of content.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:title': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-      'max-characters': 'Avoid 70 characters or more.',
-    },
-    meta: {
-      info: 'The <code>twitter:title</code> element defines the title of content.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
-    'max-characters': 70,
+    info: 'The <code>twitter:title</code> element defines the title of content.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:image': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-      'image-min-size': 'Avoid images smaller than 144x144 or less.',
-      'image-max-size': 'Avoid images larger than 4096x4096 or more.',
-    },
-    'image-min-size': {
-      height: 144,
-      width: 144,
-    },
-    'image-max-size': {
-      height: 4096,
-      width: 4096,
-    },
-    meta: {
-      info: 'The <code>twitter:image</code> element defines the URL of image to use in the card. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>twitter:image</code> element defines the URL of image to use in the card. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:image:alt': {
-    required: true,
-    message: {
-      required: 'This property is required according to the Twitter documentation.',
-      'max-characters': 'Avoid 420 characters or more.',
-    },
-    meta: {
-      info: 'The <code>twitter:image:alt</code> element defines a text description of the image conveying the essential nature of an image to users who are visually impaired.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
-    'max-characters': 420,
+    info: 'The <code>twitter:image:alt</code> element defines a text description of the image conveying the essential nature of an image to users who are visually impaired.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:player': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the HTTPS URL of player iframe.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
-    },
+    info: 'The <code>twitter</code> element defines the HTTPS URL of player iframe.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:player:width': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the width of iframe in pixels.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
-    },
+    info: 'The <code>twitter</code> element defines the width of iframe in pixels.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:player:height': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the height of iframe in pixels.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
-    },
+    info: 'The <code>twitter</code> element defines the height of iframe in pixels.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:player:stream': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the URL to raw video or audio stream.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
-    },
+    info: 'The <code>twitter</code> element defines the URL to raw video or audio stream.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:app:id:iphone': {
-    meta: {
-      info: 'The <code>twitter</code> element defines your app ID in the iTunes App Store (Note: NOT your bundle ID).',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines your app ID in the iTunes App Store (Note: NOT your bundle ID).',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:id:ipad': {
-    meta: {
-      info: 'The <code>twitter</code> element defines your app ID in the iTunes App Store.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines your app ID in the iTunes App Store.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:id:googleplay': {
-    meta: {
-      info: 'The <code>twitter</code> element defines your app ID in the Google Play Store.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines your app ID in the Google Play Store.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:url:iphone': {
-    meta: {
-      info: 'The <code>twitter</code> element defines your app’s custom URL scheme (you must include ”://” after your scheme name).',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines your app’s custom URL scheme (you must include ”://” after your scheme name).',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:url:ipad': {
-    meta: {
-      info: 'The <code>twitter</code> element defines your app’s custom URL scheme.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines your app’s custom URL scheme.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:url:googleplay': {
-    meta: {
-      info: 'The <code>twitter</code> element defines your app’s custom URL scheme.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines your app’s custom URL scheme.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:country': {
-    meta: {
-      info: 'The <code>twitter</code> element defines.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:name:iphone': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the name of your iPhone app.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines the name of your iPhone app.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:name:ipad': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the name of your iPad optimized app.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines the name of your iPad optimized app.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:name:googleplay': {
-    meta: {
-      info: 'The <code>twitter</code> element defines the name of your Android app.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-    },
+    info: 'The <code>twitter</code> element defines the name of your Android app.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'og:title': {
-    meta: {
-      info: 'The <code>og:title</code> element is used as a fallback if <code>twitter:title</code> is not present.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>og:title</code> element is used as a fallback if <code>twitter:title</code> is not present.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:type': {
-    meta: {
-      info: 'The <code>og:type</code> element is used as a fallback if <code>twitter:card</code> is not present.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>og:type</code> element is used as a fallback if <code>twitter:card</code> is not present.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:image': {
-    meta: {
-      info: 'The <code>og:image</code> element is used as a fallback if <code>twitter:image</code> is not present.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>og:image</code> element is used as a fallback if <code>twitter:image</code> is not present.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:url': {
-    meta: {
-      info: 'The <code>og:url</code> element defines the canonical URL of your object.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>og:url</code> element defines the canonical URL of your object.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:description': {
-    meta: {
-      info: 'The <code>og:description</code> element is used as a fallback if <code>twitter:description</code> is not present.',
-      link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
-    },
+    info: 'The <code>og:description</code> element is used as a fallback if <code>twitter:description</code> is not present.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 };
-
-export default twitterSchema;

--- a/projects/@shared/views/twitter/twitter.view.vue
+++ b/projects/@shared/views/twitter/twitter.view.vue
@@ -22,17 +22,18 @@
     </panel-section>
     <panel-section title="Properties">
       <properties-list>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
           :image="item.image"
           :type="item.type"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
           :required="item.required"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -62,12 +63,13 @@ import { computed, onMounted, ref, watch } from 'vue';
 import createAbsoluteUrl from '@shared/lib/create-absolute-url';
 import { findImageDimensions, findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
 import getTheme from '@shared/lib/theme';
-import schema from './schema';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link';
 import PanelSection from '@shared/components/panel-section';
 import PreviewIframe from '@shared/components/preview-iframe';
-import PropertiesItem from '@shared/components/properties-item';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import PropertiesList from '@shared/components/properties-list';
 
 export default {
@@ -79,6 +81,7 @@ export default {
   },
 
   setup: props => {
+    const validation = ref({});
     const imageDimensions = ref({ height: undefined, width: undefined });
     const validCards = ref([ 'summary', 'summary_large_image', 'app', 'player' ]);
     const supportedCards = ref([ 'summary', 'summary_large_image' ]);
@@ -301,6 +304,7 @@ export default {
       findImageDimensions(props.headData.head, name)
         .then(dimensions => imageDimensions.value = dimensions);
     };
+    const getTooltipInfo = term => (info[term] ?? {});
 
     watch(og.value.image, (value, oldValue) => {
       if (value !== oldValue) {
@@ -316,26 +320,25 @@ export default {
 
     onMounted(() => getImageDimensions());
 
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
+
     return {
       card,
       supportedCards,
       isValidCard,
       isSupportedCard,
-      title,
-      description,
-      image,
-      og,
-      twitter,
       previewUrl,
       metaData,
-      schema,
+      getTooltipInfo,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
     PreviewIframe,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
   },
 };


### PR DESCRIPTION
Twitter view now uses new Joi validation.

## What change(s) were made
- The `twitter.view.vue` view now uses the new Joi validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/IRLNSFYd](https://trello.com/c/IRLNSFYd)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
