### PR TITLE
Feat/whatsapp validation

### DIFF
--- a/projects/@shared/views/whatsapp/schema.js
+++ b/projects/@shared/views/whatsapp/schema.js
@@ -1,58 +1,57 @@
-const whatsappSchema = {
+import Joi from '../../lib/validator';
+
+export const schema = Joi.object({
+  'og:title': Joi.string()
+    .max(65)
+    .required()
+    .messages({
+      'string.max': 'Avoid 65 characters or more.',
+      'string.empty': 'This property is required for rich links on WhatsApp.',
+    }),
+
+  'og:image': Joi.image()
+    .minDimensions(200, 300)
+    .required()
+    .messages({
+      'any.required': 'This property is required for rich links on WhatsApp.',
+    }),
+
+  'og:description': Joi.string()
+    .max(155)
+    .required()
+    .messages({
+      'string.max': 'Avoid 155 characters or more.',
+      'any.required': 'This property is required for rich links on WhatsApp.',
+    }),
+
+  'og:url': Joi.string()
+    .required()
+    .messages({
+      'string.empty': 'This property is required for rich links on WhatsApp.',
+    }),
+
+  'og:type': Joi.string()
+    .allow(''),
+});
+
+export const info = {
   'og:title': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on WhatsApp.',
-      'max-characters': 'Avoid 65 characters or more.',
-    },
-    meta: {
-      info: 'The <code>og:title</code> element defines the title of your rich link.',
-    },
-    'max-characters': 65,
+    info: 'The <code>og:title</code> element defines the title of your rich link.',
   },
 
   'og:image': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on WhatsApp.',
-      'image-min-size': 'Avoid images smaller than 300x200 or less.',
-    },
-    'image-min-size': {
-      height: 200,
-      width: 300,
-    },
-    meta: {
-      info: 'The <code>og:image</code> element defines the image of your rich link.',
-    },
+    info: 'The <code>og:image</code> element defines the image of your rich link.',
   },
 
   'og:description': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on WhatsApp.',
-      'max-characters': 'Avoid 155 characters or more.',
-    },
-    meta: {
-      info: 'The <code>og:description</code> element defines the description of your rich link.',
-    },
-    'max-characters': 155,
+    info: 'The <code>og:description</code> element defines the description of your rich link.',
   },
 
   'og:url': {
-    required: true,
-    message: {
-      required: 'This property is required for rich links on WhatsApp.',
-    },
-    meta: {
-      info: 'The <code>og:url</code> element defines the canonical URL of your rich link.',
-    },
+    info: 'The <code>og:url</code> element defines the canonical URL of your rich link.',
   },
 
   'og:type': {
-    meta: {
-      info: 'The <code>og:type</code> element defines the type of content, whether it’s an article, video, or rich media.',
-    },
+    info: 'The <code>og:type</code> element defines the type of content, whether it’s an article, video, or rich media.',
   },
 };
-
-export default whatsappSchema;

--- a/projects/@shared/views/whatsapp/whatsapp.view.vue
+++ b/projects/@shared/views/whatsapp/whatsapp.view.vue
@@ -17,17 +17,18 @@
     </panel-section>
     <panel-section title="Properties">
       <properties-list>
-        <properties-item
+        <properties-item-new
           v-for="item in metaData"
           :key="item.term"
           :term="item.term"
           :value="item.value"
           :image="item.image"
           :type="item.type"
-          :schema="schema"
+          :tooltip="getTooltipInfo(item.term)"
+          :validation="validation"
           :required="item.required"
         >
-        </properties-item>
+        </properties-item-new>
       </properties-list>
     </panel-section>
     <panel-section title="Resources">
@@ -48,15 +49,16 @@
 </template>
 
 <script>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import createAbsoluteUrl from '@shared/lib/create-absolute-url';
 import { findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
-import schema from './schema';
+import validate from '@shared/lib/validate-data';
+import { schema, info } from './schema';
 
 import ExternalLink from '@shared/components/external-link';
 import PanelSection from '@shared/components/panel-section';
 import PreviewIframe from '@shared/components/preview-iframe';
-import PropertiesItem from '@shared/components/properties-item';
+import PropertiesItemNew from '@shared/components/properties-item-new';
 import PropertiesList from '@shared/components/properties-list';
 
 export default {
@@ -68,6 +70,7 @@ export default {
   },
 
   setup: props => {
+    const validation = ref({});
     const hasRequiredData = computed(() => (
       (og.value.title || props.headData.head.title) &&
       (og.value.description || props.headData.headDescription)
@@ -83,9 +86,6 @@ export default {
       propertyValue('og:title') || props.headData.head.title || ''
     ));
     const description = computed(() => (og.value.description));
-    const hasDescription = computed(() => (
-      og.value.description !== null && og.value.description.length > 0
-    ));
     const image = computed(() => (
       og.value.image !== undefined ? absoluteUrl(og.value.image) : og.value.image
     ));
@@ -131,26 +131,26 @@ export default {
     ]));
 
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
+    const getTooltipInfo = term => (info[term] ?? {});
     const propertyValue = propName =>
       findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
 
+    validate(metaData.value, schema)
+      .then(result => validation.value = result);
+
     return {
       hasRequiredData,
-      og,
-      title,
-      description,
-      hasDescription,
-      image,
       previewUrl,
       metaData,
-      schema,
+      getTooltipInfo,
+      validation,
     };
   },
   components: {
     ExternalLink,
     PanelSection,
     PreviewIframe,
-    PropertiesItem,
+    PropertiesItemNew,
     PropertiesList,
   },
 };


### PR DESCRIPTION
Whatsapp view now uses new Joi validation.

## What change(s) were made
- The `whatsapp.view.vue` view now uses the new Joi validation.

## How to test
  - Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).
  - Checkout changes locally and compare the dev extension with the released extension.

## Related Trello ticket(s)
- [https://trello.com/c/yP9Hl7Zs](https://trello.com/c/yP9Hl7Zs)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
