### PR TITLE
Feat/ordered favicons

### DIFF
--- a/projects/@shared/views/apple-ios/apple-ios.view.vue
+++ b/projects/@shared/views/apple-ios/apple-ios.view.vue
@@ -109,15 +109,20 @@ export default {
       ];
     });
 
-    const touchIcons = computed(() => {
-      return props.headData.head.link
+    const touchIcons = computed(() => (
+      props.headData.head.link
         .filter(link => link.rel === 'apple-touch-icon')
         .map(icon => ({
           ...icon,
           url: absoluteUrl(icon.href),
           term: [ icon.rel, icon.sizes ],
-        }));
-    });
+        }))
+        .sort((a, b) => {
+          const sizeA = a.sizes ? a.sizes.split('x')[0] : 0;
+          const sizeB = b.sizes ? b.sizes.split('x')[0] : 0;
+          return parseInt(sizeA, 10) > parseInt(sizeB, 10) ? 1 : -1;
+        })
+    ));
 
     const startupImages = computed(() => {
       return props.headData.head.link

--- a/projects/@shared/views/apple-ios/apple-ios.view.vue
+++ b/projects/@shared/views/apple-ios/apple-ios.view.vue
@@ -36,8 +36,8 @@
       </div>
       <properties-list v-else>
         <properties-item
-          v-for="item in startupImages"
-          :key="item.term"
+          v-for="image in startupImages"
+          :key="image.term"
           :term="image.term"
           :value="image.url"
           :image="image"

--- a/projects/@shared/views/apple-ios/apple-ios.view.vue
+++ b/projects/@shared/views/apple-ios/apple-ios.view.vue
@@ -124,15 +124,15 @@ export default {
         })
     ));
 
-    const startupImages = computed(() => {
-      return props.headData.head.link
+    const startupImages = computed(() => (
+      props.headData.head.link
         .filter(link => link.rel === 'apple-touch-startup-image')
         .map(image => ({
           ...image,
           url: absoluteUrl(image.href),
           term: [ image.rel, image.sizes, image.media ],
-        }));
-    });
+        }))
+    ));
 
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
 

--- a/projects/@shared/views/favicon/favicon.view.vue
+++ b/projects/@shared/views/favicon/favicon.view.vue
@@ -49,10 +49,16 @@ export default {
 
   setup: props => {
     const favicons = computed(() => (
-      findFavicons(props.headData.head).map(image => ({
-        ...image,
-        term: [ image.type, image.rel, image.sizes ],
-      }))
+      findFavicons(props.headData.head)
+        .map(image => ({
+          ...image,
+          term: [ image.type, image.rel, image.sizes ],
+        }))
+        .sort((a, b) => {
+          const sizeA = a.sizes ? a.sizes.split('x')[0] : 0;
+          const sizeB = b.sizes ? b.sizes.split('x')[0] : 0;
+          return parseInt(sizeA, 10) > parseInt(sizeB, 10) ? 1 : -1;
+        })
     ));
 
     return {


### PR DESCRIPTION
Array of found favicons is now ordered based on the `sizes` attribute.

## What change(s) were made
- Return arrays sorted on `sizes` attribute.
- Use implicit returns

## How to test
- Compare the preview link with [heads-up-web-app.netlify.app](https://heads-up-web-app.netlify.app/).

## Related Trello ticket(s)
- [https://trello.com/c/L1Px7w6e](https://trello.com/c/L1Px7w6e)

## Checks
- [x] Checked browser extension (light & dark theme).
- [x] Checked web app.
