### PR TITLE
Feat: Multiple Google Preview Improvements.

### DIFF
--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -286,6 +286,7 @@ export default {
   .properties-item__value--code {
     background-color: #eee;
     border-radius: 2px;
+    color: #555;
     flex: initial;
     line-height: 1.15;
     padding: 0.125rem 0.25rem 0.25rem;

--- a/projects/@shared/views/google/google.view.vue
+++ b/projects/@shared/views/google/google.view.vue
@@ -67,7 +67,7 @@
 <script>
 import { computed, ref } from 'vue';
 import { format as formatDate } from 'timeago.js';
-import { findMetaContent } from '@shared/lib/find-meta';
+import { findFavicons, findMetaContent } from '@shared/lib/find-meta';
 import { TABS } from '@shared/lib/constants.js';
 import { TYPES, splitTypes } from '@shared/lib/google-utils.js';
 import getTheme from '@shared/lib/theme';
@@ -104,6 +104,8 @@ export default {
       const params = new URLSearchParams();
 
       params.set('description', findMetaContent(head, 'description'));
+      params.set('favicon', findFavicons(props.headData.head)?.[0].url || '');
+      params.set('isMobile', openTab.value === 'mobile');
       params.set('theme', getTheme());
       params.set('title', head.title);
       params.set('url', head.url);
@@ -126,15 +128,16 @@ export default {
       // Structured Data
       params.set('aggregateRatingValue', data['aggregateRating']?.ratingValue);
       params.set('aggregateReviewCount', data['aggregateRating']?.reviewCount);
+      params.set('breadcrumbSegments', getBreadcrumbSegments(data['itemListElement']));
       params.set('dateModified', formatDate(data['dateModified']));
       params.set('description', data['description']);
+      params.set('favicon', findFavicons(props.headData.head)?.[0].url || '');
       params.set('headline', data['headline']);
       params.set('image', getImageUrl(data['image']));
-      params.set('breadcrumbSegments', getBreadcrumbSegments(data['itemListElement']));
+      params.set('isMobile', openTab.value === 'mobile');
       params.set('name', data['name']);
       params.set('offerPrice', formatPrice(data['offers']?.price, data['offers']?.priceCurrency));
       params.set('offerSellerName', data['offers']?.seller?.name);
-      params.set('platform', 'web-app');
       params.set('publisherLogo', data['publisher']?.logo?.url);
       params.set('publisherName', data['publisher']?.name);
       params.set('theme', getTheme());

--- a/projects/rich-previews/@shared/css/google.css
+++ b/projects/rich-previews/@shared/css/google.css
@@ -45,6 +45,7 @@ html {
 
 .scroll-container--fake {
   margin-top: -0.5rem;
+  max-width: 40rem;
   padding-right: 1.5rem;
   position: relative;
   width: 100%;
@@ -68,8 +69,9 @@ html {
 }
 
 .scroll-container__inner {
-  display: inline-block;
   padding: 0.5rem;
+  max-width: 40rem;
+  min-width: 20rem;
 }
 
 .warning-message {

--- a/projects/rich-previews/src/google-article-desktop/google-article-desktop.css
+++ b/projects/rich-previews/src/google-article-desktop/google-article-desktop.css
@@ -1,6 +1,10 @@
 @import "../../@shared/css/defaults.css";
 @import "../../@shared/css/google.css";
 
+.scroll-container__inner {
+  min-width: 40rem;
+}
+
 /* Article */
 .article {
   background-color: var(--color-white);
@@ -10,7 +14,6 @@
   display: block;
   height: 283px;
   overflow: hidden;
-  width: 212px;
 }
 
 .article--no-hover {
@@ -20,7 +23,6 @@
 .article--variant {
   height: auto;
   padding: 1rem;
-  width: 652px;
 }
 
 .article--variant:hover .article__headline {
@@ -44,7 +46,6 @@
   height: 119px;
   object-fit: cover;
   object-position: center;
-  width: 100%;
 }
 
 .article--variant .article__image {
@@ -136,6 +137,7 @@
 
 .article-carrousel__item {
   margin-right: 0.5rem;
+  width: 13.125rem;
 }
 
 .article-carrousel__item:last-of-type {

--- a/projects/rich-previews/src/google-article-desktop/google-article-desktop.html
+++ b/projects/rich-previews/src/google-article-desktop/google-article-desktop.html
@@ -12,7 +12,6 @@
     <div id="app">
       <h1 class="iframe-heading" :class="{ 'iframe-heading--dark-mode': isDarkMode }">NewsArticle</h1>
       <div v-if="!hasRequiredData" class="warning-message" :class="{
-        'warning-message--web-app': platform === 'web-app',
         'warning-message--dark-mode': isDarkMode
       }">
         <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">

--- a/projects/rich-previews/src/google-article-desktop/google-article-desktop.js
+++ b/projects/rich-previews/src/google-article-desktop/google-article-desktop.js
@@ -26,7 +26,6 @@ const app = Vue.createApp({
       headline,
       image,
       isDarkMode: params.get('theme') === 'dark',
-      platform: params.get('platform'),
       publisherLogo,
       publisherName,
     };

--- a/projects/rich-previews/src/google-article-mobile/google-article-mobile.css
+++ b/projects/rich-previews/src/google-article-mobile/google-article-mobile.css
@@ -8,9 +8,6 @@
   box-shadow: 0 1px 6px rgba(32, 33, 36, 0.28);
   cursor: pointer;
   display: block;
-  max-width: 652px;
-  min-width: 320px;
-  overflow: hidden;
   padding: 1rem;
 }
 
@@ -83,8 +80,6 @@
   box-shadow: 0 1px 6px rgba(32, 33, 36, 0.28);
   list-style: none;
   margin-top: 1rem;
-  max-width: 652px;
-  min-width: 320px;
   overflow: hidden;
 }
 

--- a/projects/rich-previews/src/google-article-mobile/google-article-mobile.html
+++ b/projects/rich-previews/src/google-article-mobile/google-article-mobile.html
@@ -12,7 +12,6 @@
     <div id="app">
       <h1 class="iframe-heading" :class="{ 'iframe-heading--dark-mode': isDarkMode }">NewsArticle</h1>
       <div v-if="!hasRequiredData" class="warning-message" :class="{
-        'warning-message--web-app': platform === 'web-app',
         'warning-message--dark-mode': isDarkMode
       }">
         <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">

--- a/projects/rich-previews/src/google-article-mobile/google-article-mobile.js
+++ b/projects/rich-previews/src/google-article-mobile/google-article-mobile.js
@@ -26,7 +26,6 @@ const app = Vue.createApp({
       headline,
       image,
       isDarkMode: params.get('theme') === 'dark',
-      platform: params.get('platform'),
       publisherLogo,
       publisherName,
     };

--- a/projects/rich-previews/src/google-breadcrumb/google-breadcrumb.css
+++ b/projects/rich-previews/src/google-breadcrumb/google-breadcrumb.css
@@ -1,11 +1,11 @@
 @import "../../@shared/css/defaults.css";
 @import "../../@shared/css/google.css";
 
-/* Breadcrumb */
-.google-breadcrumb {
-  max-width: 37.5rem;
+.scroll-container__inner {
+  padding: 0;
 }
 
+/* Breadcrumb */
 .google-breadcrumb__link {
   text-decoration: none;
 }
@@ -29,11 +29,27 @@
 
 .google-breadcrumb__url-segment {
   display: inline-block;
+  height: 1rem;
+  line-height: 1;
   margin-right: 0.2rem;
+  vertical-align: middle;
+}
+
+.google-breadcrumb__url-segment--favicon {
+  aspect-ratio: auto 16 / 16;
+  display: inline-block;
+  height: 1rem;
+  margin-right: 0.75rem;
+  vertical-align: middle;
+  width: 1rem;
 }
 
 .google-breadcrumb__url-segment:not(:first-of-type) {
   color: var(--color-shuttle-gray);
+}
+
+.google-breadcrumb--mobile .google-breadcrumb__url-segment:nth-of-type(2) {
+  color: inherit;
 }
 
 .google-breadcrumb__url-segment:not(:last-of-type)::after {
@@ -44,6 +60,10 @@
 .google-breadcrumb--dark .google-breadcrumb__url-segment:not(:first-of-type),
 .google-breadcrumb--dark .google-breadcrumb__url-segment:not(:last-of-type)::after {
   color: var(--color-manatee);
+}
+
+.google-breadcrumb--dark.google-breadcrumb--mobile .google-breadcrumb__url-segment:nth-of-type(2) {
+  color: inherit;
 }
 
 .google-breadcrumb__url-segment:last-of-type {
@@ -84,6 +104,10 @@
   color: var(--color-cornflower-blue);
 }
 
+.google-breadcrumb--mobile .google-breadcrumb__title {
+  -webkit-line-clamp: 2;
+}
+
 .google-breadcrumb__description {
   -webkit-line-clamp: 2;
   color: var(--color-abbey);
@@ -94,4 +118,8 @@
 
 .google-breadcrumb--dark .google-breadcrumb__description {
   color: var(--color-silver-sand);
+}
+
+.google-breadcrumb--mobile .google-breadcrumb__description {
+  -webkit-line-clamp: 3;
 }

--- a/projects/rich-previews/src/google-breadcrumb/google-breadcrumb.html
+++ b/projects/rich-previews/src/google-breadcrumb/google-breadcrumb.html
@@ -11,24 +11,33 @@
   <body>
     <div id="app">
       <h1 class="iframe-heading" :class="{ 'iframe-heading--dark-mode': isDarkMode }">Breadcrumb</h1>
-      <div v-if="breadcrumbSegments.length > 1" class="google-breadcrumb" :class="{ 'google-breadcrumb--dark': isDarkMode }">
-        <a class="google-breadcrumb__link" rel="noopener" target="_blank" :href="url">
-          <ul class="google-breadcrumb__url">
-            <li
-              class="google-breadcrumb__url-segment"
-              v-for="(segment, index) in breadcrumbSegments"
-              :key="index"
-            >
-              {{ segment }}
-            </li>
-          </ul>
-          <p class="google-breadcrumb__title">{{ title }}</p>
-        </a>
-        <p class="google-breadcrumb__description" v-html="description">
+      <div v-if="breadcrumbSegments.length > 1" class="scroll-container">
+        <div class="scroll-container__inner">
+          <div class="google-breadcrumb" :class="{
+            'google-breadcrumb--dark': isDarkMode,
+            'google-breadcrumb--mobile': isMobile
+          }">
+            <a class="google-breadcrumb__link" rel="noopener" target="_blank" :href="url">
+              <ul class="google-breadcrumb__url">
+                <li v-if="favicon && isMobile" class="google-breadcrumb__url-segment--favicon">
+                  <img :src="favicon" alt="">
+                </li>
+                <li
+                  class="google-breadcrumb__url-segment"
+                  v-for="(segment, index) in breadcrumbSegments"
+                  :key="index"
+                >
+                  {{ segment }}
+                </li>
+              </ul>
+              <p class="google-breadcrumb__title">{{ title }}</p>
+            </a>
+            <p class="google-breadcrumb__description" v-html="description">
+          </div>
+        </div>
       </div>
 
       <div v-else class="warning-message" :class="{
-        'warning-message--web-app': platform === 'web-app',
         'warning-message--dark-mode': isDarkMode
       }">
         <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">

--- a/projects/rich-previews/src/google-breadcrumb/google-breadcrumb.js
+++ b/projects/rich-previews/src/google-breadcrumb/google-breadcrumb.js
@@ -3,9 +3,8 @@ import { truncateString } from '../../../@shared/lib/google-utils.js';
 const app = Vue.createApp({
   setup() {
     const params = new URL(window.location.href).searchParams;
-    const description = params.get('headDescription');
     const breadcrumbSegments = params.get('breadcrumbSegments');
-    const title = params.get('headTitle');
+    const description = params.get('headDescription');
     const url = params.get('headUrl');
 
     const domainWithoutProtocol = new URL(url).origin.replace(/(^\w+:|^)\/\//, '');
@@ -15,8 +14,10 @@ const app = Vue.createApp({
         `${ domainWithoutProtocol },${ breadcrumbSegments || '' }`, 46
       ).split(',').filter(Boolean),
       description: description.replace(/ ?<br ?\/?> ?/gi, ' '),
+      favicon: params.get('favicon'),
       isDarkMode: params.get('theme') === 'dark',
-      title,
+      isMobile: params.get('isMobile') === 'true',
+      title: params.get('headTitle'),
       url,
     };
   },

--- a/projects/rich-previews/src/google-default/google-default.css
+++ b/projects/rich-previews/src/google-default/google-default.css
@@ -1,11 +1,11 @@
 @import "../../@shared/css/defaults.css";
 @import "../../@shared/css/google.css";
 
-/* Default */
-.google-default {
-  max-width: 37.5rem;
+.scroll-container__inner {
+  padding: 0;
 }
 
+/* Default */
 .google-default__link {
   text-decoration: none;
 }
@@ -29,11 +29,27 @@
 
 .google-default__url-segment {
   display: inline-block;
+  height: 1rem;
+  line-height: 1;
   margin-right: 0.2rem;
+  vertical-align: middle;
+}
+
+.google-default__url-segment--favicon {
+  aspect-ratio: auto 16 / 16;
+  display: inline-block;
+  height: 1rem;
+  margin-right: 0.75rem;
+  vertical-align: middle;
+  width: 1rem;
 }
 
 .google-default__url-segment:not(:first-of-type) {
   color: var(--color-shuttle-gray);
+}
+
+.google-default--mobile .google-default__url-segment:nth-of-type(2) {
+  color: inherit;
 }
 
 .google-default__url-segment:not(:last-of-type)::after {
@@ -44,6 +60,10 @@
 .google-default--dark .google-default__url-segment:not(:first-of-type),
 .google-default--dark .google-default__url-segment:not(:last-of-type)::after {
   color: var(--color-manatee);
+}
+
+.google-default--dark.google-default--mobile .google-default__url-segment:nth-of-type(2) {
+  color: inherit;
 }
 
 .google-default__url-segment:last-of-type {
@@ -84,6 +104,10 @@
   color: var(--color-cornflower-blue);
 }
 
+.google-default--mobile .google-default__title {
+  -webkit-line-clamp: 2;
+}
+
 .google-default__description {
   -webkit-line-clamp: 2;
   color: var(--color-abbey);
@@ -94,4 +118,8 @@
 
 .google-default--dark .google-default__description {
   color: var(--color-silver-sand);
+}
+
+.google-default--mobile .google-default__description {
+  -webkit-line-clamp: 3;
 }

--- a/projects/rich-previews/src/google-default/google-default.html
+++ b/projects/rich-previews/src/google-default/google-default.html
@@ -10,20 +10,30 @@
 
   <body>
     <div id="app">
-      <div class="google-default" :class="{ 'google-default--dark': isDarkMode }">
-        <a class="google-default__link" rel="noopener" target="_blank" :href="url">
-          <ul class="google-default__url">
-            <li
-              class="google-default__url-segment"
-              v-for="(segment, index) in urlSegments"
-              :key="index"
-            >
-              {{ segment }}
-            </li>
-          </ul>
-          <p class="google-default__title">{{ title }}</p>
-        </a>
-        <p class="google-default__description" v-html="description">
+      <div class="scroll-container">
+        <div class="scroll-container__inner">
+          <div class="google-default" :class="{
+            'google-default--dark': isDarkMode,
+            'google-default--mobile': isMobile
+          }">
+            <a class="google-default__link" rel="noopener" target="_blank" :href="url">
+              <ul class="google-default__url">
+                <li v-if="favicon && isMobile" class="google-default__url-segment--favicon">
+                  <img :src="favicon" alt="">
+                </li>
+                <li
+                  class="google-default__url-segment"
+                  v-for="(segment, index) in urlSegments"
+                  :key="index"
+                >
+                  {{ segment }}
+                </li>
+              </ul>
+              <p class="google-default__title">{{ title }}</p>
+            </a>
+            <p class="google-default__description" v-html="description">
+          </div>
+        </div>
       </div>
     </div>
 

--- a/projects/rich-previews/src/google-default/google-default.js
+++ b/projects/rich-previews/src/google-default/google-default.js
@@ -4,13 +4,14 @@ const app = Vue.createApp({
   setup() {
     const params = new URL(window.location.href).searchParams;
     const description = params.get('description');
-    const title = params.get('title');
     const url = params.get('url');
 
     return {
       description: description.replace(/ ?<br ?\/?> ?/gi, ' '),
+      favicon: params.get('favicon'),
       isDarkMode: params.get('theme') === 'dark',
-      title,
+      isMobile: params.get('isMobile') === 'true',
+      title: params.get('title'),
       url,
       urlSegments: getUrlSegments(url),
     };

--- a/projects/rich-previews/src/google-product-desktop/google-product-desktop.css
+++ b/projects/rich-previews/src/google-product-desktop/google-product-desktop.css
@@ -1,8 +1,8 @@
 @import "../../@shared/css/defaults.css";
 @import "../../@shared/css/google.css";
 
-.scroll-container--fake {
-  max-width: 70.25rem;
+.scroll-container__inner {
+  min-width: 40rem;
 }
 
 /* Product */
@@ -10,8 +10,6 @@
   background-color: var(--color-white);
   border-radius: 0.5rem;
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.16);
-  max-width: 70.25rem;
-  min-width: 38.875rem;
   padding: 0.75rem;
 }
 
@@ -49,6 +47,7 @@
   flex-direction: column;
   justify-content: center;
   padding: 0.75rem;
+  width: 100%;
 }
 
 .product__merchant-name,

--- a/projects/rich-previews/src/google-product-desktop/google-product-desktop.html
+++ b/projects/rich-previews/src/google-product-desktop/google-product-desktop.html
@@ -12,7 +12,6 @@
     <div id="app">
       <h1 class="iframe-heading" :class="{ 'iframe-heading--dark-mode': isDarkMode }">Product</h1>
       <div v-if="!hasRequiredData" class="warning-message" :class="{
-        'warning-message--web-app': platform === 'web-app',
         'warning-message--dark-mode': isDarkMode
       }">
         <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">

--- a/projects/rich-previews/src/google-product-desktop/google-product-desktop.html
+++ b/projects/rich-previews/src/google-product-desktop/google-product-desktop.html
@@ -73,7 +73,7 @@
                 </div>
               </div>
             </li>
-            <li v-for="index in 6" :key="index" class="product-carrousel__item">
+            <li v-for="index in 3" :key="index" class="product-carrousel__item">
               <div class="product product--no-hover">
                 <div class="product__wrapper">
                   <div class="product__image product__skeleton-image"></div>

--- a/projects/rich-previews/src/google-product-desktop/google-product-desktop.js
+++ b/projects/rich-previews/src/google-product-desktop/google-product-desktop.js
@@ -37,7 +37,6 @@ const app = Vue.createApp({
       name,
       offerPrice,
       offerSellerName,
-      platform: params.get('platform'),
     };
   },
 });

--- a/projects/rich-previews/src/google-product-mobile/google-product-mobile.css
+++ b/projects/rich-previews/src/google-product-mobile/google-product-mobile.css
@@ -1,10 +1,6 @@
 @import "../../@shared/css/defaults.css";
 @import "../../@shared/css/google.css";
 
-.scroll-container--fake {
-  max-width: 46rem;
-}
-
 /* Product */
 .product {
   background-color: var(--color-white);
@@ -13,8 +9,6 @@
   color: var(--color-cape-cod);
   font-size: 0.75rem;
   line-height: 1.25rem;
-  max-width: 46rem;
-  min-width: 20rem;
   padding: 0.75rem 0;
   position: relative;
 }
@@ -42,6 +36,7 @@
 
 .product__content {
   padding-right: 0.625rem;
+  width: 100%;
 }
 
 .product__name {

--- a/projects/rich-previews/src/google-product-mobile/google-product-mobile.html
+++ b/projects/rich-previews/src/google-product-mobile/google-product-mobile.html
@@ -12,7 +12,6 @@
     <div id="app">
       <h1 class="iframe-heading" :class="{ 'iframe-heading--dark-mode': isDarkMode }">Product</h1>
       <div v-if="!hasRequiredData" class="warning-message" :class="{
-        'warning-message--web-app': platform === 'web-app',
         'warning-message--dark-mode': isDarkMode
       }">
         <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">

--- a/projects/rich-previews/src/google-product-mobile/google-product-mobile.js
+++ b/projects/rich-previews/src/google-product-mobile/google-product-mobile.js
@@ -37,7 +37,6 @@ const app = Vue.createApp({
       name,
       offerPrice,
       offerSellerName,
-      platform: params.get('platform'),
     };
   },
 });


### PR DESCRIPTION
## What change(s) were made
- Give the `product` preview a fixed-width similar to the `article` preview. It just works and looks better, sadly.
- The `default` and `breadcrumb` previews need custom mobile styling.
- A lot of random css fixes, cleanup and improvements.

## How to test
- Check the new mobile breadcrumb/default previews, and the update product/article previews.

## Related Trello ticket(s)
- https://trello.com/c/UfSa8IqH

## Checks
- [X] Checked browser extension (light & dark theme).
- [X] Checked web app.
