### PR TITLE
Feat: Humanize the Google View properties list.

### DIFF
--- a/projects/@shared/components/preview-iframe.vue
+++ b/projects/@shared/components/preview-iframe.vue
@@ -52,7 +52,7 @@ export default {
     const isLoading = ref(true);
 
     const setIframeHeight = debounce(() => {
-      iframeHeight.value = parseInt(iframe.value.contentWindow.document.body.scrollHeight) + 'px';
+      iframeHeight.value = parseInt(iframe.value?.contentWindow.document.body.scrollHeight) + 'px';
     }, 300);
 
     /**

--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -287,7 +287,6 @@ export default {
     background-color: #eee;
     border-radius: 2px;
     color: #555;
-    flex: initial;
     line-height: 1.15;
     padding: 0.125rem 0.25rem 0.25rem;
   }

--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -280,7 +280,13 @@ export default {
     line-height: 1;
     margin-left: 1rem;
     max-width: 500px;
+    overflow-wrap: break-word;
     word-break: break-word;
+    word-wrap: break-word;
+  }
+
+  .properties-item__value--image {
+    word-break: break-all;
   }
 
   .properties-item__value--code {

--- a/projects/@shared/lib/google-utils.js
+++ b/projects/@shared/lib/google-utils.js
@@ -49,6 +49,23 @@ export const truncateString = (str, num) => {
   return str.slice(0, num) + '...';
 };
 
+export const getBreadcrumbSegments = itemListElement => {
+  if (!itemListElement?.length > 0) return [];
+  return itemListElement
+    .map(item => item?.name || item?.item?.name)
+    .filter(Boolean);
+};
+
+export const getImageUrl = img => {
+  if (Array.isArray(img)) {
+    return getImageUrl(img[0]);
+  } else if (typeof img === 'string') {
+    return img.split(', ')[0];
+  }
+
+  return img?.url;
+};
+
 export const getUrlSegments = url => {
   return truncateString(
     url

--- a/projects/@shared/views/google/google.view.vue
+++ b/projects/@shared/views/google/google.view.vue
@@ -46,6 +46,7 @@
           :key="item.term"
           :term="item.term"
           :value="item.value"
+          :tooltip="item.tooltip"
           :image="item.image"
           :type="item.type"
           :required="true"
@@ -66,10 +67,16 @@
 
 <script>
 import { computed, ref } from 'vue';
+import { metadata } from './metadata.js';
 import { format as formatDate } from 'timeago.js';
 import { findFavicons, findMetaContent } from '@shared/lib/find-meta';
 import { TABS } from '@shared/lib/constants.js';
-import { TYPES, splitTypes } from '@shared/lib/google-utils.js';
+import {
+  getBreadcrumbSegments,
+  getImageUrl,
+  splitTypes,
+  TYPES
+} from '@shared/lib/google-utils.js';
 import getTheme from '@shared/lib/theme';
 
 import ExternalLink from '@shared/components/external-link';
@@ -154,83 +161,8 @@ export default {
     const getMetaData = type => {
       const { head } = props.headData;
       const data = mergedData.value[type][0];
-      const metaData = {
-        BreadcrumbList: [
-          { term: '@type', value: data['@type'] },
-          { term: 'head:title', value: head.title },
-          { term: 'head:description', value: findMetaContent(head, 'description') },
-          {
-            term:'itemListElement',
-            value: `[${ getBreadcrumbSegments(data['itemListElement'])
-              .map(segment => `"${ segment }"`)
-              .join(', ') }]`,
-            type: 'code',
-          },
-        ],
-        NewsArticle: [
-          { term: '@type', value: data['@type'] },
-          { term: 'headline', value: data['headline'] },
-          { term: 'description', value: data['description'] },
-          { term: 'dateModified', value: data['dateModified'] },
-          { term: 'publisher - name', value: data['publisher']?.name },
-          {
-            term: 'publisher - logo',
-            value: getImageUrl(data['publisher']?.logo),
-            image: {
-              href: getImageUrl(data['publisher']?.logo),
-              url: getImageUrl(data['publisher']?.logo),
-            },
-            type: 'image',
-          },
-          {
-            term: 'image',
-            value: getImageUrl(data['image']),
-            image: {
-              href: getImageUrl(data['image']),
-              url: getImageUrl(data['image']),
-            },
-            type: 'image',
-          },
-        ],
-        Product: [
-          { term: '@type', value: data['@type'] },
-          { term: 'name', value: data['name'] },
-          { term: 'description', value: data['description'] },
-          { term: 'offers - price', value: data['offers']?.price },
-          { term: 'offers - priceCurrency', value: data['offers']?.priceCurrency },
-          { term: 'offers - seller - name', value: data['offers']?.seller?.name },
-          { term: 'aggregateRating - ratingValue', value: data['aggregateRating']?.ratingValue },
-          { term: 'aggregateRating - reviewCount', value: data['aggregateRating']?.reviewCount },
-          {
-            term: 'image',
-            value: getImageUrl(data['image']),
-            image: {
-              href: getImageUrl(data['image']),
-              url: getImageUrl(data['image']),
-            },
-            type: 'image',
-          },
-        ],
-      };
 
-      return metaData[type];
-    };
-
-    const getImageUrl = img => {
-      if (Array.isArray(img)) {
-        return getImageUrl(img[0]);
-      } else if (typeof img === 'string') {
-        return img.split(', ')[0];
-      }
-
-      return img?.url;
-    };
-
-    const getBreadcrumbSegments = itemListElement => {
-      if (!itemListElement?.length > 0) return [];
-      return itemListElement
-        .map(item => item?.name || item?.item?.name)
-        .filter(Boolean);
+      return metadata(data, head, type);
     };
 
     const formatPrice = (price, currency) => {

--- a/projects/@shared/views/google/metadata.js
+++ b/projects/@shared/views/google/metadata.js
@@ -8,17 +8,17 @@ export const metadata = (data, head, type) => {
       {
         term: 'type',
         value: data['@type'],
-        tooltip: tooltip[type]?.type ?? {},
+        tooltip: tooltip[type].type,
       },
       {
         term: 'title (head)',
         value: head.title,
-        tooltip: tooltip[type]?.headTitle ?? {},
+        tooltip: tooltip[type].headTitle,
       },
       {
         term: 'description (head)',
         value: findMetaContent(head, 'description'),
-        tooltip: tooltip[type]?.headDescription ?? {},
+        tooltip: tooltip[type].headDescription,
       },
       {
         term: 'breadcrumb segments',
@@ -26,74 +26,44 @@ export const metadata = (data, head, type) => {
           .map(segment => `"${ segment }"`)
           .join(', ') }]`,
         type: 'code',
-        tooltip: tooltip[type]?.itemListElement ?? {},
+        tooltip: tooltip[type].itemListElement,
       },
     ],
     NewsArticle: [
-      { term: '@type', value: data['@type'] },
-      { term: 'headline', value: data['headline'] },
-      { term: 'description', value: data['description'] },
-      { term: 'dateModified', value: data['dateModified'] },
-      { term: 'publisher - name', value: data['publisher']?.name },
-      {
-        term: 'publisher - logo',
-        value: getImageUrl(data['publisher']?.logo),
-        image: {
-          href: getImageUrl(data['publisher']?.logo),
-          url: getImageUrl(data['publisher']?.logo),
-        },
-        type: 'image',
-      },
-      {
-        term: 'image',
-        value: getImageUrl(data['image']),
-        image: {
-          href: getImageUrl(data['image']),
-          url: getImageUrl(data['image']),
-        },
-        type: 'image',
-      },
-    ],
-    Product: [
       {
         term: 'type',
         value: data['@type'],
-        tooltip: tooltip[type]?.type ?? {},
+        tooltip: tooltip[type].type,
       },
       {
-        term: 'name',
-        value: data.name,
-        tooltip: tooltip[type]?.name ?? {},
+        term: 'headline',
+        value: data.headline,
+        tooltip: tooltip[type].headline,
       },
       {
         term: 'description',
         value: data.description,
-        tooltip: tooltip[type]?.description ?? {},
+        tooltip: tooltip[type].description,
       },
       {
-        term: 'price',
-        value: data.offers?.price,
-        tooltip: tooltip[type]?.offersPrice ?? {},
+        term: 'date modified',
+        value: data.dateModified,
+        tooltip: tooltip[type].dateModified,
       },
       {
-        term: 'currency',
-        value: data.offers?.priceCurrency,
-        tooltip: tooltip[type]?.offersPriceCurrency ?? {},
+        term: 'publisher\'s name',
+        value: data.publisher?.name,
+        tooltip: tooltip[type].publisherName,
       },
       {
-        term: 'seller\'s name',
-        value: data.offers?.seller?.name,
-        tooltip: tooltip[type]?.offersSellerName ?? {},
-      },
-      {
-        term: 'rating',
-        value: data.aggregateRating?.ratingValue,
-        tooltip: tooltip[type]?.aggregateRatingRatingValue ?? {},
-      },
-      {
-        term: 'review count',
-        value: data.aggregateRating?.reviewCount,
-        tooltip: tooltip[type]?.aggregateRatingReviewCount ?? {},
+        term: 'publisher\'s logo',
+        value: getImageUrl(data.publisher?.logo),
+        image: {
+          href: getImageUrl(data.publisher?.logo),
+          url: getImageUrl(data.publisher?.logo),
+        },
+        type: 'image',
+        tooltip: tooltip[type].publisherLogo,
       },
       {
         term: 'image',
@@ -103,7 +73,59 @@ export const metadata = (data, head, type) => {
           url: getImageUrl(data.image),
         },
         type: 'image',
-        tooltip: tooltip[type]?.image ?? {},
+        tooltip: tooltip[type].image,
+      },
+    ],
+    Product: [
+      {
+        term: 'type',
+        value: data['@type'],
+        tooltip: tooltip[type].type,
+      },
+      {
+        term: 'name',
+        value: data.name,
+        tooltip: tooltip[type].name,
+      },
+      {
+        term: 'description',
+        value: data.description,
+        tooltip: tooltip[type].description,
+      },
+      {
+        term: 'price',
+        value: data.offers?.price,
+        tooltip: tooltip[type].offersPrice,
+      },
+      {
+        term: 'currency',
+        value: data.offers?.priceCurrency,
+        tooltip: tooltip[type].offersPriceCurrency,
+      },
+      {
+        term: 'seller\'s name',
+        value: data.offers?.seller?.name,
+        tooltip: tooltip[type].offersSellerName,
+      },
+      {
+        term: 'rating',
+        value: data.aggregateRating?.ratingValue,
+        tooltip: tooltip[type].aggregateRatingRatingValue,
+      },
+      {
+        term: 'review count',
+        value: data.aggregateRating?.reviewCount,
+        tooltip: tooltip[type].aggregateRatingReviewCount,
+      },
+      {
+        term: 'image',
+        value: getImageUrl(data.image),
+        image: {
+          href: getImageUrl(data.image),
+          url: getImageUrl(data.image),
+        },
+        type: 'image',
+        tooltip: tooltip[type].image,
       },
     ],
   }[type];

--- a/projects/@shared/views/google/metadata.js
+++ b/projects/@shared/views/google/metadata.js
@@ -1,0 +1,97 @@
+import { tooltip } from './schema.js';
+import { findMetaContent } from '@shared/lib/find-meta';
+import { getBreadcrumbSegments, getImageUrl } from '@shared/lib/google-utils.js';
+
+export const metadata = (data, head, type) => {
+  return {
+    BreadcrumbList: [
+      { term: '@type', value: data['@type'] },
+      { term: 'head:title', value: head.title },
+      { term: 'head:description', value: findMetaContent(head, 'description') },
+      {
+        term: 'itemListElement',
+        value: `[${ getBreadcrumbSegments(data['itemListElement'])
+          .map(segment => `"${ segment }"`)
+          .join(', ') }]`,
+        type: 'code',
+      },
+    ],
+    NewsArticle: [
+      { term: '@type', value: data['@type'] },
+      { term: 'headline', value: data['headline'] },
+      { term: 'description', value: data['description'] },
+      { term: 'dateModified', value: data['dateModified'] },
+      { term: 'publisher - name', value: data['publisher']?.name },
+      {
+        term: 'publisher - logo',
+        value: getImageUrl(data['publisher']?.logo),
+        image: {
+          href: getImageUrl(data['publisher']?.logo),
+          url: getImageUrl(data['publisher']?.logo),
+        },
+        type: 'image',
+      },
+      {
+        term: 'image',
+        value: getImageUrl(data['image']),
+        image: {
+          href: getImageUrl(data['image']),
+          url: getImageUrl(data['image']),
+        },
+        type: 'image',
+      },
+    ],
+    Product: [
+      {
+        term: 'type',
+        value: data['@type'],
+        tooltip: tooltip[type]?.type ?? {},
+      },
+      {
+        term: 'name',
+        value: data.name,
+        tooltip: tooltip[type]?.name ?? {},
+      },
+      {
+        term: 'description',
+        value: data.description,
+        tooltip: tooltip[type]?.description ?? {},
+      },
+      {
+        term: 'price',
+        value: data.offers?.price,
+        tooltip: tooltip[type]?.offersPrice ?? {},
+      },
+      {
+        term: 'currency',
+        value: data.offers?.priceCurrency,
+        tooltip: tooltip[type]?.offersPriceCurrency ?? {},
+      },
+      {
+        term: 'seller\'s name',
+        value: data.offers?.seller?.name,
+        tooltip: tooltip[type]?.offersSellerName ?? {},
+      },
+      {
+        term: 'rating',
+        value: data.aggregateRating?.ratingValue,
+        tooltip: tooltip[type]?.aggregateRatingRatingValue ?? {},
+      },
+      {
+        term: 'review count',
+        value: data.aggregateRating?.reviewCount,
+        tooltip: tooltip[type]?.aggregateRatingReviewCount ?? {},
+      },
+      {
+        term: 'image',
+        value: getImageUrl(data.image),
+        image: {
+          href: getImageUrl(data.image),
+          url: getImageUrl(data.image),
+        },
+        type: 'image',
+        tooltip: tooltip[type]?.image ?? {},
+      },
+    ],
+  }[type];
+};

--- a/projects/@shared/views/google/metadata.js
+++ b/projects/@shared/views/google/metadata.js
@@ -5,15 +5,28 @@ import { getBreadcrumbSegments, getImageUrl } from '@shared/lib/google-utils.js'
 export const metadata = (data, head, type) => {
   return {
     BreadcrumbList: [
-      { term: '@type', value: data['@type'] },
-      { term: 'head:title', value: head.title },
-      { term: 'head:description', value: findMetaContent(head, 'description') },
       {
-        term: 'itemListElement',
-        value: `[${ getBreadcrumbSegments(data['itemListElement'])
+        term: 'type',
+        value: data['@type'],
+        tooltip: tooltip[type]?.type ?? {},
+      },
+      {
+        term: 'title (head)',
+        value: head.title,
+        tooltip: tooltip[type]?.headTitle ?? {},
+      },
+      {
+        term: 'description (head)',
+        value: findMetaContent(head, 'description'),
+        tooltip: tooltip[type]?.headDescription ?? {},
+      },
+      {
+        term: 'breadcrumb segments',
+        value: `[${ getBreadcrumbSegments(data.itemListElement)
           .map(segment => `"${ segment }"`)
           .join(', ') }]`,
         type: 'code',
+        tooltip: tooltip[type]?.itemListElement ?? {},
       },
     ],
     NewsArticle: [

--- a/projects/@shared/views/google/schema.js
+++ b/projects/@shared/views/google/schema.js
@@ -14,6 +14,29 @@ export const tooltip = {
       info: `Based on <code>"BreadcrumbList.itemListElement"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
     },
   },
+  NewsArticle: {
+    type: {
+      info: `Based on <code>"NewsArticle['@type']"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    headline: {
+      info: `Based on <code>"NewsArticle.headline"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    description: {
+      info: `Based on <code>"NewsArticle.description"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    dateModified: {
+      info: `Based on <code>"NewsArticle.dateModified"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    publisherName: {
+      info: `Based on <code>"NewsArticle.publisher.name"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    publisherLogo: {
+      info: `Based on <code>"NewsArticle.publisher.logo"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    image: {
+      info: `Based on <code>"NewsArticle.image"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+  },
   Product: {
     type: {
       info: `Based on <code>"Product['@type']"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,

--- a/projects/@shared/views/google/schema.js
+++ b/projects/@shared/views/google/schema.js
@@ -1,5 +1,19 @@
 /* eslint-disable */
 export const tooltip = {
+  BreadcrumbList: {
+    type: {
+      info: `Based on <code>"BreadcrumbList['@type']"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    headTitle: {
+      info: `Based on <code>"&lt;title>...&lt;/title>"</code> in the <a class="app-tooltip__link" href="#/meta">head</a>.`,
+    },
+    headDescription: {
+      info: `Based on <code>"&lt;meta name="description" content="...">"</code> in the <a class="app-tooltip__link" href="#/meta">head</a>.`,
+    },
+    itemListElement: {
+      info: `Based on <code>"BreadcrumbList.itemListElement"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+  },
   Product: {
     type: {
       info: `Based on <code>"Product['@type']"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,

--- a/projects/@shared/views/google/schema.js
+++ b/projects/@shared/views/google/schema.js
@@ -1,0 +1,32 @@
+/* eslint-disable */
+export const tooltip = {
+  Product: {
+    type: {
+      info: `Based on <code>"Product['@type']"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    name: {
+      info: `Based on <code>"Product.name"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    description: {
+      info: `Based on <code>"Product.description"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    offersPrice: {
+      info: `Based on <code>"Product.offers.price"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    offersPriceCurrency: {
+      info: `Based on <code>"Product.offers.priceCurrency"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    offersSellerName: {
+      info: `Based on <code>"Product.offers.seller.name"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    aggregateRatingRatingValue: {
+      info: `Based on <code>"Product.aggregateRating.ratingValue"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    aggregateRatingReviewCount: {
+      info: `Based on <code>"Product.aggregateRating.reviewCount"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+    image: {
+      info: `Based on <code>"Product.image"</code> in <a class="app-tooltip__link" href="#/structured-data">Structured Data</a>.`,
+    },
+  },
+};


### PR DESCRIPTION
## What change(s) were made
- De logica voor de metadata van de Google View is verplaats naar een externe bestaand.
- De properties list van de Google View heeft nu tooltips met informatie over waar de data vandaan komt.
- De keys van de properties list zijn aangepast naar een iets meer menselijke tekst.

## How to test
- Ga naar [deze URL](https://www.ah.nl/producten/product/wi206745/ah-excellent-feeststol).
- Open Heads Up en vervolgens de Google tab. Als goed is, heeft elk property nu een tooltip.

## Related Trello ticket(s)
- https://trello.com/c/oAx36FTJ

## Checks
- [X] Checked browser extension (light & dark theme).
- [X] Checked web app.
