### PR TITLE
Feat: Strikethrough non-supported `og:` and `twitter:` properties.

### DIFF
--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -10,7 +10,7 @@
               v-if="item"
               :key="index"
               class="properties-item__term"
-              :class="{'properties-item__term--not-supported': isNotSupported}"
+              :class="{'properties-item__term--unsupported': isUnsupported}"
             >
               {{ item }}
             </span>
@@ -20,7 +20,7 @@
         <span
           v-else
           class="properties-item__term"
-          :class="{'properties-item__term--not-supported': isNotSupported}"
+          :class="{'properties-item__term--unsupported': isUnsupported}"
         >
           {{ term }}
         </span>
@@ -116,7 +116,7 @@
     <dd
       v-else
       class="properties-item__value"
-      :class="{'properties-item__value--not-supported': isNotSupported}"
+      :class="{'properties-item__value--unsupported': isUnsupported}"
     >
       <span v-if="value">{{ value }}</span>
     </dd>
@@ -168,6 +168,7 @@ export default {
         'image',
         'link',
         'string',
+        'unsupported',
         'urls',
       ].indexOf(type) !== -1,
     },
@@ -213,8 +214,8 @@ export default {
     isUrlsValue() {
       return this.type === 'urls' && this.value;
     },
-    isNotSupported() {
-      return this.type === 'notSupported' && this.value;
+    isUnsupported() {
+      return this.type === 'unsupported' && this.value;
     },
     showItem() {
       return this.term && this.value || this.required;
@@ -300,12 +301,12 @@ export default {
     word-wrap: break-word;
   }
 
-  .properties-item__term--not-supported,
-  .properties-item__value--not-supported {
+  .properties-item__term--unsupported,
+  .properties-item__value--unsupported {
     text-decoration: line-through;
   }
 
-  .properties-item__value--not-supported {
+  .properties-item__value--unsupported {
     opacity: .5;
   }
 

--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -6,13 +6,22 @@
 
         <template v-if="termIsArray">
           <template v-for="(item, index) in term">
-            <span v-if="item" :key="index" class="properties-item__term">
+            <span
+              v-if="item"
+              :key="index"
+              class="properties-item__term"
+              :class="{'properties-item__term--not-supported': isNotSupported}"
+            >
               {{ item }}
             </span>
           </template>
         </template>
 
-        <span v-else class="properties-item__term">
+        <span
+          v-else
+          class="properties-item__term"
+          :class="{'properties-item__term--not-supported': isNotSupported}"
+        >
           {{ term }}
         </span>
 
@@ -104,7 +113,11 @@
       <span class="properties-item__strikethrough">{{ splittedStringEnd }}</span>
     </dd>
 
-    <dd v-else class="properties-item__value">
+    <dd
+      v-else
+      class="properties-item__value"
+      :class="{'properties-item__value--not-supported': isNotSupported}"
+    >
       <span v-if="value">{{ value }}</span>
     </dd>
   </div>
@@ -200,6 +213,9 @@ export default {
     isUrlsValue() {
       return this.type === 'urls' && this.value;
     },
+    isNotSupported() {
+      return this.type === 'notSupported' && this.value;
+    },
     showItem() {
       return this.term && this.value || this.required;
     },
@@ -281,6 +297,20 @@ export default {
     margin-left: 1rem;
     max-width: 500px;
     word-break: break-word;
+    word-wrap: break-word;
+  }
+
+  .properties-item__term--not-supported,
+  .properties-item__value--not-supported {
+    text-decoration: line-through;
+  }
+
+  .properties-item__value--not-supported {
+    opacity: .5;
+  }
+
+  .properties-item__value--image {
+    word-break: break-all;
   }
 
   .properties-item__value--code {

--- a/projects/@shared/views/open-graph/open-graph.view.vue
+++ b/projects/@shared/views/open-graph/open-graph.view.vue
@@ -98,7 +98,7 @@ export default {
         .map(meta => ({
           term: meta.property || meta.name,
           type: !Object.keys(info).includes(meta.property || meta.name)
-            ? 'notSupported'
+            ? 'unsupported'
             : 'string',
           value: meta.content,
         }));

--- a/projects/@shared/views/open-graph/open-graph.view.vue
+++ b/projects/@shared/views/open-graph/open-graph.view.vue
@@ -34,10 +34,10 @@
 
 <script>
 import { computed, ref } from 'vue';
-import createAbsoluteUrl from '@shared/lib/create-absolute-url';
-import { findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
-import validate from '@shared/lib/validate';
 import { schema, info } from './schema';
+import { findMetaContent, findMetaProperty } from '@shared/lib/find-meta';
+import createAbsoluteUrl from '@shared/lib/create-absolute-url';
+import validate from '@shared/lib/validate';
 
 import ExternalLink from '@shared/components/external-link';
 import PanelSection from '@shared/components/panel-section';
@@ -97,6 +97,9 @@ export default {
         )
         .map(meta => ({
           term: meta.property || meta.name,
+          type: !Object.keys(info).includes(meta.property || meta.name)
+            ? 'notSupported'
+            : 'string',
           value: meta.content,
         }));
     });

--- a/projects/@shared/views/open-graph/schema.js
+++ b/projects/@shared/views/open-graph/schema.js
@@ -1,6 +1,57 @@
 import Joi from '../../lib/validator';
 
 export const schema = Joi.object({
+  'og:audio:secure_url': Joi.string()
+    .allow(''),
+
+  'og:audio:type': Joi.string()
+    .allow(''),
+
+  'og:audio:url': Joi.string()
+    .allow(''),
+
+  'og:audio': Joi.string()
+    .allow(''),
+
+  'og:description': Joi.string()
+    .allow(''),
+
+  'og:determiner': Joi.string()
+    .allow(''),
+
+  'og:image:alt': Joi.string()
+    .allow(''),
+
+  'og:image:height': Joi.string()
+    .allow(''),
+
+  'og:image:secure_url': Joi.string()
+    .allow(''),
+
+  'og:image:type': Joi.string()
+    .allow(''),
+
+  'og:image:url': Joi.image()
+    .allow(''),
+
+  'og:image:width': Joi.string()
+    .allow(''),
+
+  'og:image': Joi.image()
+    .required()
+    .messages({
+      'string.empty': 'This property is required according to the Open Graph protocol.',
+    }),
+
+  'og:locale:alternate': Joi.string()
+    .allow(''),
+
+  'og:locale': Joi.string()
+    .allow(''),
+
+  'og:site_name': Joi.string()
+    .allow(''),
+
   'og:title': Joi.string()
     .required()
     .messages({
@@ -13,49 +64,16 @@ export const schema = Joi.object({
       'string.empty': 'This property is required according to the Open Graph protocol.',
     }),
 
-  'og:image': Joi.image()
-    .required()
-    .messages({
-      'string.empty': 'This property is required according to the Open Graph protocol.',
-    }),
-
   'og:url': Joi.string()
     .required()
     .messages({
       'string.empty': 'This property is required according to the Open Graph protocol.',
     }),
 
-  'og:description': Joi.string()
+  'og:video:alt': Joi.string()
     .allow(''),
 
-  'og:locale': Joi.string()
-    .allow(''),
-
-  'og:site_name': Joi.string()
-    .allow(''),
-
-  'og:video': Joi.string()
-    .allow(''),
-
-  'og:image:url': Joi.image()
-    .allow(''),
-
-  'og:image:secure_url': Joi.string()
-    .allow(''),
-
-  'og:image:type': Joi.string()
-    .allow(''),
-
-  'og:image:width': Joi.string()
-    .allow(''),
-
-  'og:image:height': Joi.string()
-    .allow(''),
-
-  'og:image:alt': Joi.string()
-    .allow(''),
-
-  'og:video:url': Joi.string()
+  'og:video:height': Joi.string()
     .allow(''),
 
   'og:video:secure_url': Joi.string()
@@ -64,35 +82,37 @@ export const schema = Joi.object({
   'og:video:type': Joi.string()
     .allow(''),
 
+  'og:video:url': Joi.string()
+    .allow(''),
+
   'og:video:width': Joi.string()
     .allow(''),
 
-  'og:video:height': Joi.string()
+  'og:video': Joi.string()
     .allow(''),
-
-  'og:video:alt': Joi.string()
-    .allow(''),
+}).messages({
+  'object.unknown': 'Unknown property, <a href="https://ogp.me/" rel="noopener" target="_blank">learn more</a>.',
 });
 
 
 export const info = {
-  'og:title': {
-    info: 'The <code>og:title</code> element defines the title of your object as it should appear within the graph.',
+  'og:audio:secure_url': {
+    info: 'An alternate url to use if the webpage requires HTTPS. The <code>og:audio:secure_url</code> is an optional structured property for <code>og:audio</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:type': {
-    info: 'The <code>og:type</code> element defines the type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.',
+  'og:audio:type': {
+    info: 'A MIME type for this audio. The <code>og:audio:type</code> is an optional structured property for <code>og:audio</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:image': {
-    info: 'The <code>og:image</code> element defines an image URL which should represent your object within the graph.',
+  'og:audio:url': {
+    info: 'Identical to <code>og:audio</code> property. The <code>og:audio:url</code> is an optional structured property for <code>og:audio</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:url': {
-    info: 'The <code>og:url</code> element defines the canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/"',
+  'og:audio': {
+    info: 'The <code>og:audio</code> element defines a URL to an audio file to accompany your object.',
     link: 'https://ogp.me/',
   },
 
@@ -101,23 +121,18 @@ export const info = {
     link: 'https://ogp.me/',
   },
 
-  'og:locale': {
-    info: 'The <code>og:locale</code> element defines the locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.',
+  'og:determiner': {
+    info: 'The <code>og:determiner</code> is the word that appears before your object\'s title in a sentence.',
     link: 'https://ogp.me/',
   },
 
-  'og:site_name': {
-    info: 'The <code>og:site_name</code> element defines if your object is part of a larger web site, the name which should be displayed for the overall site. e.g., "IMDb".',
+  'og:image:alt': {
+    info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:video': {
-    info: 'The <code>og:site_name</code> element defines a URL to a video file that complements this object.',
-    link: 'https://ogp.me/',
-  },
-
-  'og:image:url': {
-    info: 'Identical to <code>og:image</code> property. The <code>og:image:url</code> is an optional structured property for <code>og:image</code>.',
+  'og:image:height': {
+    info: 'The number of pixels high. The <code>og:image:height</code> is an optional structured property for <code>og:image</code>.',
     link: 'https://ogp.me/',
   },
 
@@ -131,23 +146,58 @@ export const info = {
     link: 'https://ogp.me/',
   },
 
+  'og:image:url': {
+    info: 'Identical to <code>og:image</code> property. The <code>og:image:url</code> is an optional structured property for <code>og:image</code>.',
+    link: 'https://ogp.me/',
+  },
+
   'og:image:width': {
     info: 'The number of pixels wide. The <code>og:image:width</code> is an optional structured property for <code>og:image</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:image:height': {
-    info: 'The number of pixels high. The <code>og:image:height</code> is an optional structured property for <code>og:image</code>.',
+  'og:image': {
+    info: 'The <code>og:image</code> element defines an image URL which should represent your object within the graph.',
     link: 'https://ogp.me/',
   },
 
-  'og:image:alt': {
+  'og:locale:alternate': {
+    info: 'An array of other locales this page is available in. The <code>og:locale:alternate</code> is an optional structured property for <code>og:locale</code>..',
+    link: 'https://ogp.me/',
+  },
+
+  'og:locale': {
+    info: 'The <code>og:locale</code> element defines the locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.',
+    link: 'https://ogp.me/',
+  },
+
+  'og:site_name': {
+    info: 'The <code>og:site_name</code> element defines if your object is part of a larger web site, the name which should be displayed for the overall site. e.g., "IMDb".',
+    link: 'https://ogp.me/',
+  },
+
+  'og:title': {
+    info: 'The <code>og:title</code> element defines the title of your object as it should appear within the graph.',
+    link: 'https://ogp.me/',
+  },
+
+  'og:type': {
+    info: 'The <code>og:type</code> element defines the type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.',
+    link: 'https://ogp.me/',
+  },
+
+  'og:url': {
+    info: 'The <code>og:url</code> element defines the canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/"',
+    link: 'https://ogp.me/',
+  },
+
+  'og:video:alt': {
     info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:video:url': {
-    info: 'Identical to <code>og:video</code> property. The <code>og:video:url</code> is an optional structured property for <code>og:video</code>.',
+  'og:video:height': {
+    info: 'The number of pixels high. The <code>og:video:height</code> is an optional structured property for <code>og:video</code>.',
     link: 'https://ogp.me/',
   },
 
@@ -161,18 +211,18 @@ export const info = {
     link: 'https://ogp.me/',
   },
 
+  'og:video:url': {
+    info: 'Identical to <code>og:video</code> property. The <code>og:video:url</code> is an optional structured property for <code>og:video</code>.',
+    link: 'https://ogp.me/',
+  },
+
   'og:video:width': {
     info: 'The number of pixels wide. The <code>og:video:width</code> is an optional structured property for <code>og:video</code>.',
     link: 'https://ogp.me/',
   },
 
-  'og:video:height': {
-    info: 'The number of pixels high. The <code>og:video:height</code> is an optional structured property for <code>og:video</code>.',
-    link: 'https://ogp.me/',
-  },
-
-  'og:video:alt': {
-    info: 'A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt. The <code>og:image:alt</code> is an optional structured property for <code>og:image</code>.',
+  'og:video': {
+    info: 'The <code>og:site_name</code> element defines a URL to a video file that complements this object.',
     link: 'https://ogp.me/',
   },
 };

--- a/projects/@shared/views/twitter/schema.js
+++ b/projects/@shared/views/twitter/schema.js
@@ -118,6 +118,8 @@ export const schema = Joi.object({
 
   'og:description': Joi.string()
     .allow(''),
+}).messages({
+  'object.unknown': 'Unknown property, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup" rel="noopener" target="_blank">learn more</a>.',
 });
 
 export const info = {

--- a/projects/@shared/views/twitter/twitter.view.vue
+++ b/projects/@shared/views/twitter/twitter.view.vue
@@ -154,6 +154,22 @@ export default {
       params.set('theme', getTheme());
       return `/previews/twitter/twitter.html?${ params }`;
     });
+    const unsupportedProperties = computed(() => {
+      const { meta } = props.headData.head;
+      return meta
+        .filter(meta =>
+          meta.property?.startsWith('twitter:') ||
+          meta.name?.startsWith('twitter:')
+        )
+        .filter(meta =>
+          !Object.keys(info).includes(meta.property || meta.name)
+        )
+        .map(meta => ({
+          term: meta.property || meta.name,
+          type: 'unsupported',
+          value: meta.content,
+        }));
+    });
     const metaData = computed(() => ([
       {
         term: 'og:type',
@@ -294,6 +310,7 @@ export default {
         term: 'twitter:app:name:googleplay',
         value: twitter.value.appNameGoogle,
       },
+      ...unsupportedProperties.value,
     ]));
 
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);


### PR DESCRIPTION
## What change(s) were made
Als een website `og:` of `twitter:` meta-properties toevoegt die niet bestaan, dan tonen we ze doorgestreept in de `<properties-list>`, met een error tooltip.

## How to test
Deze [website](https://www.commonsensemedia.org/book-reviews/harry-potter-and-the-chamber-of-secrets) heeft 3 `twitter:` unsupported properties.

## Related Trello ticket(s)
- https://trello.com/c/ah7LHI9s

## Checks
- [X] Checked browser extension (light & dark theme).
- [X] Checked web app.
