### PR TITLE
Feat: Twitter Parsing Rules - Global.

### DIFF
--- a/projects/@shared/components/properties-item.vue
+++ b/projects/@shared/components/properties-item.vue
@@ -191,7 +191,9 @@ export default {
       return this.errors?.[0]?.message.trim();
     },
     errors() {
-      return this.validation.errors.filter(item => (item.path[0] === this.term));
+      return this.validation.errors.filter(item =>
+        item.path[0] === this.term || item.context.peers?.includes(this.term)
+      );
     },
     hasErrors() {
       return this.validation.errors && this.errors.length;
@@ -218,7 +220,7 @@ export default {
       return this.type === 'unsupported' && this.value;
     },
     showItem() {
-      return this.term && this.value || this.required;
+      return (this.term && this.value) || this.hasErrors || this.hasWarnings;
     },
     showTooltip() {
       return Boolean(this.term && this.tooltip.info) || Boolean(this.hasErrors || this.hasWarnings);

--- a/projects/@shared/views/twitter/schema.js
+++ b/projects/@shared/views/twitter/schema.js
@@ -1,265 +1,201 @@
 import Joi from '../../lib/validator';
 
 export const schema = Joi.object({
-  'twitter:card': Joi.string()
-    .required()
-    .messages({
-      'string.empty': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:card': Joi.string(),
 
-  'twitter:site': Joi.string()
-    .required()
-    .messages({
-      'string.empty': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:site:id': Joi.number(),
+  'twitter:site': Joi.string().pattern(/^@/).max(16).messages({
+    'string.pattern.base': 'Twitter usernames must start with a <code>"@"</code>.',
+    'string.max': 'Twitter usernames can\'t be longer than 15 characters (excluding the "@").',
+  }),
 
-  'twitter:site:id': Joi.string()
-    .required()
-    .messages({
-      'string.empty': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:creator:id': Joi.number(),
+  'twitter:creator': Joi.string().pattern(/^@/).max(16).messages({
+    'string.pattern.base': 'Twitter usernames must start with a <code>"@"</code>.',
+    'string.max': 'Twitter usernames can\'t be longer than 15 characters (excluding the "@").',
+  }),
 
-  'twitter:creator': Joi.string()
-    .allow(''),
+  'twitter:description': Joi.string().max(200).messages({
+    'string.max': '<code>"twitter:description"</code> has a maximum of 200 characters.',
+  }),
 
-  'twitter:creator:id': Joi.string()
-    .allow(''),
+  'twitter:title': Joi.string().max(70).messages({
+    'string.max': '<code>"twitter:title"</code> has a maximum of 70 characters.',
+  }),
 
-  'twitter:description': Joi.string()
-    .max(200)
-    .required()
-    .messages({
-      'string.max': 'Avoid 200 characters or more.',
-      'string.empty': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:image': Joi.image().minDimensions(144, 144).maxDimensions(4096, 4096),
+  'twitter:image:alt': Joi.string().max(420).messages({
+    'string.max': '<code>"twitter:image:alt"</code> has a maximum of 420 characters.',
+  }),
 
-  'twitter:title': Joi.string()
-    .max(70)
-    .required()
-    .messages({
-      'string.max': 'Avoid 70 characters or more.',
-      'string.empty': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:player': Joi.string(),
+  'twitter:player:width': Joi.number(),
+  'twitter:player:height': Joi.number(),
+  'twitter:player:stream': Joi.string(),
 
-  'twitter:image': Joi.image()
-    .minDimensions(144, 144)
-    .maxDimensions(4096, 4096)
-    .required()
-    .messages({
-      'any.required': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:app:name:iphone': Joi.string(),
+  'twitter:app:id:iphone': Joi.number(),
+  'twitter:app:url:iphone': Joi.string(),
 
-  'twitter:image:alt': Joi.string()
-    .max(420)
-    .required()
-    .messages({
-      'string.max': 'Avoid 420 characters or more.',
-      'string.empty': 'This property is required according to the Twitter documentation.',
-    }),
+  'twitter:app:name:ipad': Joi.string(),
+  'twitter:app:id:ipad': Joi.number(),
+  'twitter:app:url:ipad': Joi.string(),
 
-  'twitter:player': Joi.string()
-    .allow(''),
+  'twitter:app:name:googleplay': Joi.string(),
+  'twitter:app:id:googleplay': Joi.number(),
+  'twitter:app:url:googleplay': Joi.string(),
 
-  'twitter:player:width': Joi.string()
-    .allow(''),
-
-  'twitter:player:height': Joi.string()
-    .allow(''),
-
-  'twitter:player:stream': Joi.string()
-    .allow(''),
-
-  'twitter:app:id:iphone': Joi.string()
-    .allow(''),
-
-  'twitter:app:id:ipad': Joi.string()
-    .allow(''),
-
-  'twitter:app:id:googleplay': Joi.string()
-    .allow(''),
-
-  'twitter:app:url:iphone': Joi.string()
-    .allow(''),
-
-  'twitter:app:url:ipad': Joi.string()
-    .allow(''),
-
-  'twitter:app:url:googleplay': Joi.string()
-    .allow(''),
-
-  'twitter:app:country': Joi.string()
-    .allow(''),
-
-  'twitter:app:name:iphone': Joi.string()
-    .allow(''),
-
-  'twitter:app:name:ipad': Joi.string()
-    .allow(''),
-
-  'twitter:app:name:googleplay': Joi.string()
-    .allow(''),
-
-  'og:title': Joi.string()
-    .allow(''),
-
-  'og:type': Joi.string()
-    .allow(''),
-
-  'og:image': Joi.image()
-    .minDimensions(144, 144)
-    .maxDimensions(4096, 4096)
-    .required()
-    .messages({
-      'any.required': 'This property is required according to the Twitter documentation.',
-    }),
-
-  'og:url': Joi.string()
-    .allow(''),
-
-  'og:description': Joi.string()
-    .allow(''),
-}).messages({
-  'object.unknown': 'Unknown property, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup" rel="noopener" target="_blank">learn more</a>.',
-});
+  'og:title': Joi.string(),
+  'og:type': Joi.string(),
+  'og:image': Joi.image().minDimensions(144, 144).maxDimensions(4096, 4096),
+  'og:url': Joi.string(),
+  'og:description': Joi.string(),
+})
+  .or('twitter:card', 'og:type')
+  .or('twitter:card', 'og:title')
+  .or('twitter:card', 'og:description')
+  .or('twitter:site', 'twitter:site:id')
+  .or('twitter:description', 'og:description')
+  .or('twitter:title', 'og:title')
+  .or('twitter:image', 'og:image')
+  .messages({
+    'object.missing': 'One of these properties <code>{#peers}</code> are required.',
+    'object.unknown': '<code>{#label}</code> is an unknown property, for more information, <a href="https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup" rel="noopener" target="_blank">refer to the docs</a>.',
+  });
 
 export const info = {
   'twitter:card': {
-    info: 'The <code>twitter:card</code> element defines the card type. If an <code>og:type</code>, <code>og:title</code> and <code>og:description</code> exist in the markup but <code>twitter:card</code> is absent, then a summary card may be rendered.',
+    info: 'The <code>"twitter:card"</code> element defines the card type. If an <code>"og:type"</code>, <code>"og:title"</code> and <code>"og:description"</code> exist in the markup but <code>"twitter:card"</code> is absent, then a summary card may be rendered.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards',
   },
 
   'twitter:site': {
-    info: 'The <code>twitter:site</code> element defines the @username of website. Either <code>twitter:site</code> or <code>twitter:site:id</code> is required.',
+    info: 'The <code>"twitter:site"</code> element defines the @username of website. Either <code>"twitter:site"</code> or <code>"twitter:site:id"</code> is required.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:site:id': {
-    info: 'The <code>twitter:site:id</code> element defines the @username of website. Either <code>twitter:site</code> or <code>twitter:site:id</code> is required.',
+    info: 'The <code>"twitter:site:id"</code> element defines the @username of website. Either <code>"twitter:site"</code> or <code>"twitter:site:id"</code> is required.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:creator': {
-    info: 'The <code>twitter:creator</code> element defines the @username of content creator.',
+    info: 'The <code>"twitter:creator"</code> element defines the @username of content creator.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:creator:id': {
-    info: 'The <code>twitter:creator:id</code> element defines the Twitter user ID of content creator.',
+    info: 'The <code>"twitter:creator:id"</code> element defines the Twitter user ID of content creator.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:description': {
-    info: 'The <code>twitter:description</code> element defines the description of content.',
+    info: 'The <code>"twitter:description"</code> element defines the description of content.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:title': {
-    info: 'The <code>twitter:title</code> element defines the title of content.',
+    info: 'The <code>"twitter:title"</code> element defines the title of content.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:image': {
-    info: 'The <code>twitter:image</code> element defines the URL of image to use in the card. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.',
+    info: 'The <code>"twitter:image"</code> element defines the URL of image to use in the card. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:image:alt': {
-    info: 'The <code>twitter:image:alt</code> element defines a text description of the image conveying the essential nature of an image to users who are visually impaired.',
+    info: 'The <code>"twitter:image:alt"</code> element defines a text description of the image conveying the essential nature of an image to users who are visually impaired.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'twitter:player': {
-    info: 'The <code>twitter</code> element defines the HTTPS URL of player iframe.',
+    info: 'The <code>"twitter:player"</code> element defines the HTTPS URL of player iframe.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:player:width': {
-    info: 'The <code>twitter</code> element defines the width of iframe in pixels.',
+    info: 'The <code>"twitter:player:width"</code> element defines the width of iframe in pixels.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:player:height': {
-    info: 'The <code>twitter</code> element defines the height of iframe in pixels.',
+    info: 'The <code>"twitter:player:height"</code> element defines the height of iframe in pixels.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
   'twitter:player:stream': {
-    info: 'The <code>twitter</code> element defines the URL to raw video or audio stream.',
+    info: 'The <code>"twitter:player:stream"</code> element defines the URL to raw video or audio stream.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card',
   },
 
+  'twitter:app:name:iphone': {
+    info: 'The <code>"twitter:app:name:iphone"</code> element defines the name of your iPhone app.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
+  },
+
   'twitter:app:id:iphone': {
-    info: 'The <code>twitter</code> element defines your app ID in the iTunes App Store (Note: NOT your bundle ID).',
-    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-  },
-
-  'twitter:app:id:ipad': {
-    info: 'The <code>twitter</code> element defines your app ID in the iTunes App Store.',
-    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-  },
-
-  'twitter:app:id:googleplay': {
-    info: 'The <code>twitter</code> element defines your app ID in the Google Play Store.',
+    info: 'The <code>"twitter:app:id:iphone"</code> element defines your app ID in the iTunes App Store (Note: NOT your bundle ID).',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:url:iphone': {
-    info: 'The <code>twitter</code> element defines your app’s custom URL scheme (you must include ”://” after your scheme name).',
+    info: 'The <code>"twitter:app:url:iphone"</code> element defines your app’s custom URL scheme (you must include ”://” after your scheme name).',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
-  'twitter:app:url:ipad': {
-    info: 'The <code>twitter</code> element defines your app’s custom URL scheme.',
-    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-  },
-
-  'twitter:app:url:googleplay': {
-    info: 'The <code>twitter</code> element defines your app’s custom URL scheme.',
-    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-  },
-
-  'twitter:app:country': {
-    info: 'The <code>twitter</code> element defines.',
-    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
-  },
-
-  'twitter:app:name:iphone': {
-    info: 'The <code>twitter</code> element defines the name of your iPhone app.',
+  'twitter:app:id:ipad': {
+    info: 'The <code>"twitter:app:id:ipad"</code> element defines your app ID in the iTunes App Store.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:name:ipad': {
-    info: 'The <code>twitter</code> element defines the name of your iPad optimized app.',
+    info: 'The <code>"twitter:app:name:ipad"</code> element defines the name of your iPad optimized app.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
+  },
+
+  'twitter:app:url:ipad': {
+    info: 'The <code>"twitter:app:url:ipad"</code> element defines your app’s custom URL scheme.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'twitter:app:name:googleplay': {
-    info: 'The <code>twitter</code> element defines the name of your Android app.',
+    info: 'The <code>"twitter:app:name:googleplay"</code> element defines the name of your Android app.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
+  },
+
+  'twitter:app:id:googleplay': {
+    info: 'The <code>"twitter:app:id:googleplay"</code> element defines your app ID in the Google Play Store.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
+  },
+
+  'twitter:app:url:googleplay': {
+    info: 'The <code>"twitter:app:url:googleplay"</code> element defines your app’s custom URL scheme.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 
   'og:title': {
-    info: 'The <code>og:title</code> element is used as a fallback if <code>twitter:title</code> is not present.',
+    info: 'The <code>"og:title"</code> element is used as a fallback if <code>"twitter:title"</code> is not present.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:type': {
-    info: 'The <code>og:type</code> element is used as a fallback if <code>twitter:card</code> is not present.',
+    info: 'The <code>"og:type"</code> element is used as a fallback if <code>"twitter:card"</code> is not present.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:image': {
-    info: 'The <code>og:image</code> element is used as a fallback if <code>twitter:image</code> is not present.',
+    info: 'The <code>"og:image"</code> element is used as a fallback if <code>"twitter:image"</code> is not present.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:url': {
-    info: 'The <code>og:url</code> element defines the canonical URL of your object.',
+    info: 'The <code>"og:url"</code> element defines the canonical URL of your object.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 
   'og:description': {
-    info: 'The <code>og:description</code> element is used as a fallback if <code>twitter:description</code> is not present.',
+    info: 'The <code>"og:description"</code> element is used as a fallback if <code>"twitter:description"</code> is not present.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup',
   },
 };

--- a/projects/@shared/views/twitter/twitter.view.vue
+++ b/projects/@shared/views/twitter/twitter.view.vue
@@ -31,7 +31,6 @@
           :type="item.type"
           :tooltip="getTooltipInfo(item.term)"
           :validation="validation"
-          :required="item.required"
         >
         </properties-item>
       </properties-list>
@@ -112,37 +111,36 @@ export default {
     const image = computed(() => (
       absoluteUrl(twitter.value.image || og.value.image)
     ));
-    const og = computed(() => ({
-      type: propertyValue('og:type'),
-      title: propertyValue('og:title'),
-      description: propertyValue('og:description'),
-      image: propertyValue('og:image'),
-      url: propertyValue('og:url'),
-    }));
     const twitter = computed(() => ({
-      appIdIphone: propertyValue('twitter:app:id:iphone'),
-      appIdIpad: propertyValue('twitter:app:id:ipad'),
-      appIdGoogle: propertyValue('twitter:app:id:googleplay'),
-      appUrlIphone: propertyValue('twitter:app:url:iphone'),
-      appUrlIpad: propertyValue('twitter:app:url:ipad'),
-      appUrlGoogle: propertyValue('twitter:app:url:googleplay'),
-      appCountry: propertyValue('twitter:app:country'),
-      appNameIphone: propertyValue('twitter:app:name:iphone'),
-      appNameIpad: propertyValue('twitter:app:name:ipad'),
-      appNameGoogle: propertyValue('twitter:app:name:googleplay'),
       card: propertyValue('twitter:card'),
-      title: propertyValue('twitter:title'),
+      site: propertyValue('twitter:site'),
+      siteId: propertyValue('twitter:site:id', { isNumber: true }),
+      creator: propertyValue('twitter:creator'),
+      creatorId: propertyValue('twitter:creator:id', { isNumber: true }),
       description: propertyValue('twitter:description'),
+      title: propertyValue('twitter:title'),
       image: propertyValue('twitter:image'),
       imageAlt: propertyValue('twitter:image:alt'),
-      site: propertyValue('twitter:site'),
-      siteId: propertyValue('twitter:site:id'),
-      creator: propertyValue('twitter:creator'),
-      creatorId: propertyValue('twitter:creator:id'),
       player: propertyValue('twitter:player'),
-      playerWidth: propertyValue('twitter:player:width'),
-      playerHeight: propertyValue('twitter:player:height'),
+      playerWidth: propertyValue('twitter:player:width', { isNumber: true }),
+      playerHeight: propertyValue('twitter:player:height', { isNumber: true }),
       playerStream: propertyValue('twitter:player:stream'),
+      appNameIphone: propertyValue('twitter:app:name:iphone'),
+      appIdIphone: propertyValue('twitter:app:id:iphone', { isNumber: true }),
+      appUrlIphone: propertyValue('twitter:app:url:iphone'),
+      appNameIpad: propertyValue('twitter:app:name:ipad'),
+      appIdIpad: propertyValue('twitter:app:id:ipad', { isNumber: true }),
+      appUrlIpad: propertyValue('twitter:app:url:ipad'),
+      appNameGoogle: propertyValue('twitter:app:name:googleplay'),
+      appIdGoogle: propertyValue('twitter:app:id:googleplay', { isNumber: true }),
+      appUrlGoogle: propertyValue('twitter:app:url:googleplay'),
+    }));
+    const og = computed(() => ({
+      title: propertyValue('og:title'),
+      type: propertyValue('og:type'),
+      image: propertyValue('og:image'),
+      url: propertyValue('og:url'),
+      description: propertyValue('og:description'),
     }));
     const previewUrl = computed(() => {
       const params = new URLSearchParams();
@@ -172,45 +170,16 @@ export default {
     });
     const metaData = computed(() => ([
       {
-        term: 'og:type',
-        value: og.value.type,
-      },
-      {
-        term: 'og:title',
-        value: og.value.title,
-      },
-      {
-        term: 'og:description',
-        value: og.value.description,
-      },
-      {
-        term: 'og:image',
-        value: og.value.image,
-        image: {
-          href: og.value.image,
-          url: absoluteUrl(og.value.image),
-        },
-        type: 'image',
-      },
-      {
-        term: 'og:url',
-        value: absoluteUrl(og.value.url),
-        type: 'link',
-      },
-      {
         term: 'twitter:card',
         value: twitter.value.card,
-        required: true,
       },
       {
         term: 'twitter:title',
         value: twitter.value.title,
-        required: true,
       },
       {
         term: 'twitter:description',
         value: twitter.value.description,
-        required: true,
       },
       {
         term: 'twitter:image',
@@ -220,19 +189,14 @@ export default {
           url: absoluteUrl(twitter.value.image),
         },
         type: 'image',
-        required: true,
       },
       {
         term: 'twitter:image:alt',
         value: twitter.value.imageAlt,
-        required: true,
       },
       {
         term: 'twitter:creator',
-        value: twitter.value.creator
-          ? `https://twitter.com/${ twitter.value.creator.slice(1) }`
-          : null,
-        type: 'link',
+        value: twitter.value.creator,
       },
       {
         term: 'twitter:creator:id',
@@ -240,16 +204,11 @@ export default {
       },
       {
         term: 'twitter:site',
-        value: twitter.value.site
-          ? `https://twitter.com/${ twitter.value.site.slice(1) }`
-          : null,
-        type: 'link',
-        required: true,
+        value: twitter.value.site,
       },
       {
         term: 'twitter:site:id',
-        value: twitter.value.site,
-        required: true,
+        value: twitter.value.siteId,
       },
       {
         term: 'twitter:player',
@@ -295,10 +254,6 @@ export default {
         type: 'link',
       },
       {
-        term: 'twitter:app:country',
-        value: twitter.value.appCountry,
-      },
-      {
         term: 'twitter:app:name:iphone',
         value: twitter.value.appNameIphone,
       },
@@ -310,17 +265,59 @@ export default {
         term: 'twitter:app:name:googleplay',
         value: twitter.value.appNameGoogle,
       },
+      {
+        term: 'og:title',
+        value: og.value.title,
+      },
+      {
+        term: 'og:type',
+        value: og.value.type,
+      },
+      {
+        term: 'og:image',
+        value: og.value.image,
+        image: {
+          href: og.value.image,
+          url: absoluteUrl(og.value.image),
+        },
+        type: 'image',
+      },
+      {
+        term: 'og:url',
+        value: absoluteUrl(og.value.url),
+        type: 'link',
+      },
+      {
+        term: 'og:description',
+        value: og.value.description,
+      },
       ...unsupportedProperties.value,
     ]));
 
+    const propertyValue = (propName, { isNumber = false } = {}) => {
+      const value =
+        findMetaProperty(props.headData.head, propName) ||
+        findMetaContent(props.headData.head, propName);
+
+      if (!value) {
+        return undefined;
+      }
+
+      if (isNumber) {
+        return Number(value) || undefined;
+      }
+
+      return value;
+    };
+
     const absoluteUrl = url => createAbsoluteUrl(props.headData.head, url);
-    const propertyValue = propName =>
-      findMetaProperty(props.headData.head, propName) || findMetaContent(props.headData.head, propName);
+
     const getImageDimensions = tagName => {
       const name = tagName ? tagName : 'og:image';
       findImageDimensions(props.headData.head, name)
         .then(dimensions => imageDimensions.value = dimensions);
     };
+
     const getTooltipInfo = term => (info[term] ?? {});
 
     watch(() => og.value.image, (value, oldValue) => {


### PR DESCRIPTION
**⚠️ Warning:** https://github.com/voorhoede/heads-up/pull/209 is hierin gemerged, review deze PR na #209.

## What change(s) were made
- Support voor fallbacks, e.g. `twitter:title` en `og:title`.
- Support voor `or` logica, e.g. value `x` of value `y` zijn required.
- Validatie voor twitter usernames (moet met een `@` starten en mag max 15 karakters zijn).
- Vele andere random fixes/improvements.
- Validatie voor numerieke values.

## How to test
- Validatie voor twitter usernames: https://github.com/
- Value `x` of value `y` zijn required: https://www.voorhoede.nl/nl/blog/bundle-splitting-with-react-s-lazy-and-suspense/
- Fallback logica, `og:image` -> `twitter:image`: https://medium.com/bigpicturenews/africa-is-planting-tens-of-millions-of-trees-in-the-desert-heres-why-7143b05781ba

## Related Trello ticket(s)
- https://trello.com/c/R9ove3XN

## Checks
- [X] Checked browser extension (light & dark theme).
- [X] Checked web app.
