### PR TITLE
Feat: Twitter Parsing Rules - App.

### DIFF
--- a/projects/@shared/views/twitter/schema.js
+++ b/projects/@shared/views/twitter/schema.js
@@ -67,16 +67,36 @@ export const schema = Joi.object({
   'twitter:player:stream': Joi.string().uri(),
 
   'twitter:app:name:iphone': Joi.string(),
-  'twitter:app:id:iphone': Joi.number(),
+
+  'twitter:app:id:iphone': Joi.number()
+    .when('twitter:card', {
+      is: 'app',
+      then: Joi.number().required(),
+    }),
+
   'twitter:app:url:iphone': Joi.string().uri(),
 
   'twitter:app:name:ipad': Joi.string(),
-  'twitter:app:id:ipad': Joi.number(),
+
+  'twitter:app:id:ipad': Joi.number()
+    .when('twitter:card', {
+      is: 'app',
+      then: Joi.number().required(),
+    }),
+
   'twitter:app:url:ipad': Joi.string().uri(),
 
   'twitter:app:name:googleplay': Joi.string(),
-  'twitter:app:id:googleplay': Joi.number(),
+
+  'twitter:app:id:googleplay': Joi.number()
+    .when('twitter:card', {
+      is: 'app',
+      then: Joi.number().required(),
+    }),
+
   'twitter:app:url:googleplay': Joi.string().uri(),
+
+  'twitter:app:country': Joi.string(),
 
   'og:title': Joi.string().max(70),
   'og:type': Joi.string(),
@@ -235,6 +255,11 @@ export const info = {
 
   'twitter:app:url:googleplay': {
     info: 'The <code>"twitter:app:url:googleplay"</code> element defines your app’s custom URL scheme.',
+    link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
+  },
+
+  'twitter:app:country': {
+    info: 'The <code>"twitter:app:country"</code> element defines your app’s store country.',
     link: 'https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/app-card',
   },
 

--- a/projects/@shared/views/twitter/twitter.view.vue
+++ b/projects/@shared/views/twitter/twitter.view.vue
@@ -134,6 +134,7 @@ export default {
       appNameGoogle: propertyValue('twitter:app:name:googleplay'),
       appIdGoogle: propertyValue('twitter:app:id:googleplay', { isNumber: true }),
       appUrlGoogle: propertyValue('twitter:app:url:googleplay'),
+      appCountry: propertyValue('twitter:app:country'),
     }));
     const og = computed(() => ({
       title: propertyValue('og:title'),
@@ -264,6 +265,10 @@ export default {
       {
         term: 'twitter:app:name:googleplay',
         value: twitter.value.appNameGoogle,
+      },
+      {
+        term: 'twitter:app:country',
+        value: twitter.value.appCountry,
       },
       {
         term: 'og:title',


### PR DESCRIPTION
**⚠️ Warning:** #212 is hierin gemerged, review deze PR na #212.

## What change(s) were made
- `twitter:app:country` teruggezet.
- Een paar values required gemaakt wanner `'twitter:card' === 'app'` is.

## Related Trello ticket(s)
- https://trello.com/c/FiFK2gWN

## Checks
- [X] Checked browser extension (light & dark theme).
- [X] Checked web app.
